### PR TITLE
Refactor README tips into separate linked pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,102 +55,14 @@ See [INSTALL.md](INSTALL.md) for full details.
 
 ## Tips & Tricks
 
-### Tip 1: Use Worktrees for Parallel Agents
-
-Git worktrees let you run multiple Claude Code agents on the same codebase without conflicts.
-
-**The problem:** If you run 2+ agents on the same repo, you get:
-- Unrelated changes in one branch
-- Agents overwriting each other's files
-- Test suites colliding on the same database
-
-**The solution:** Each agent gets its own worktree via `claude --worktree`.
-
-**But wait** - your app won't run because `.env` and other secrets don't copy over. And if both agents run tests, they'll fight over the same database.
-
-**Automate it with [worktree-sync](plugins/worktree-sync/README.md)** - uses Claude Code's `WorktreeCreate` hook to automatically symlink gitignored files into new worktrees:
-
-1. Add a `.worktreeinclude` to your project root:
-```
-.env
-.env.local
-config/master.key
-```
-
-2. Configure the hooks in `.claude/settings.json` (see [setup instructions](plugins/worktree-sync/README.md#setup))
-
-3. Run `claude --worktree` and your secrets are there automatically.
-
-Only files matching both `.worktreeinclude` AND `.gitignore` are synced. You can also configure a post-create script via `.worktreesync` for project-specific setup like database isolation.
-
-**For Rails apps**, there's also a standalone setup script for manual worktree creation:
-
-```bash
-./scripts/setup-rails-worktree.sh feature-branch
-```
-
-Get the script: [scripts/setup-rails-worktree.sh](scripts/setup-rails-worktree.sh) | [example.worktreeinclude](scripts/example.worktreeinclude) | [Git Worktrees Cheat Sheet](https://www.damiangalarza.com/downloads/git-worktree-cheatsheet?utm_source=github&utm_medium=readme&utm_campaign=claude-code-workflows)
-
-The `rails-toolkit` plugin also includes `/rails-toolkit:linear-worktree` which automates this with Linear issue context.
-
----
-
-### Tip 2: Customize Your Status Bar
-
-```bash
-claude config set --global statusLineTemplate '${cwd.basename} | ${model} | ${tokenUsage}'
-```
-
-See [configs/status-bar.md](configs/status-bar.md) for more options.
-
----
-
-### Tip 3: Compact Context Proactively
-
-Don't wait until Claude starts forgetting things. Compact when you finish a logical unit of work, switch tasks, or token usage gets high.
-
-```bash
-/compact
-```
-
----
-
-### Tip 4: Structure Your CLAUDE.md Files
-
-```markdown
-# Project Name
-
-## Overview
-One paragraph on what this project does.
-
-## Tech Stack
-- Framework: Rails 7.2
-- Database: PostgreSQL
-
-## Key Patterns
-- Service objects in app/services/
-- Result pattern for service returns
-
-## Testing
-- RSpec with FactoryBot
-- Run tests: `bin/rspec`
-```
-
----
-
-### Tip 5: Use Subagents for Focused Tasks
-
-When Claude spawns subagents, each one gets focused context. Security review? Let it spawn a security-focused subagent. Code review? Multiple specialized reviewers in parallel.
-
----
-
-### Tip 6: MCP Servers Worth Installing
-
-1. **Linear** - Project management integration
-2. **Memory** - Persistent context across sessions
-3. **Sentry** - Debug production errors
-
-See [configs/mcp-servers.md](configs/mcp-servers.md) for setup instructions.
+| Tip | Description |
+|-----|-------------|
+| [Use Worktrees for Parallel Agents](tips/worktrees-for-parallel-agents.md) | Run multiple Claude Code agents on the same codebase without conflicts |
+| [Customize Your Status Bar](tips/customize-status-bar.md) | Configure the status bar to show model, tokens, and more |
+| [Compact Context Proactively](tips/compact-context-proactively.md) | Keep Claude effective by compacting at the right times |
+| [Structure Your CLAUDE.md Files](tips/structure-claude-md-files.md) | Give Claude the project context it needs |
+| [Use Subagents for Focused Tasks](tips/use-subagents-for-focused-tasks.md) | Spawn specialized subagents for reviews, research, and more |
+| [MCP Servers Worth Installing](tips/mcp-servers-worth-installing.md) | Linear, Memory, and Sentry integrations |
 
 ---
 

--- a/tips/compact-context-proactively.md
+++ b/tips/compact-context-proactively.md
@@ -1,0 +1,21 @@
+# Compact Context Proactively
+
+Don't wait until Claude starts forgetting things. Compact when you:
+
+- **Finish a logical unit of work** - After implementing a feature or fixing a bug, compact before moving on.
+- **Switch tasks** - Context from the previous task adds noise. Clear it.
+- **Notice high token usage** - Check the status bar. If you're getting high, compact.
+
+## Usage
+
+```bash
+/compact
+```
+
+You can also provide a summary focus to guide what gets preserved:
+
+```bash
+/compact focus on the authentication changes
+```
+
+This helps Claude retain the most relevant context while freeing up space.

--- a/tips/customize-status-bar.md
+++ b/tips/customize-status-bar.md
@@ -1,0 +1,15 @@
+# Customize Your Status Bar
+
+Claude Code supports a configurable status bar that shows useful information during your session.
+
+## Quick Setup
+
+```bash
+claude config set --global statusLineTemplate '${cwd.basename} | ${model} | ${tokenUsage}'
+```
+
+This gives you the current directory, active model, and token usage at a glance.
+
+## Advanced Setup
+
+For a full-featured status bar with themes, git integration, and cost tracking, see the [Status Bar Configuration](../configs/status-bar.md) guide.

--- a/tips/mcp-servers-worth-installing.md
+++ b/tips/mcp-servers-worth-installing.md
@@ -1,0 +1,13 @@
+# MCP Servers Worth Installing
+
+MCP (Model Context Protocol) servers extend Claude Code's capabilities by connecting to external tools and services.
+
+## Recommended Servers
+
+1. **Linear** - Project management integration. Fetch issues, update status, and create branches based on issue details.
+2. **Memory** - Persistent context across sessions. Claude remembers decisions, patterns, and prior feedback.
+3. **Sentry** - Debug production errors. Pull error details, stack traces, and affected users directly into Claude.
+
+## Setup
+
+See the [MCP Server Recommendations](../configs/mcp-servers.md) guide for installation instructions, configuration options, and usage tips.

--- a/tips/structure-claude-md-files.md
+++ b/tips/structure-claude-md-files.md
@@ -1,0 +1,31 @@
+# Structure Your CLAUDE.md Files
+
+A well-structured `CLAUDE.md` gives Claude the context it needs to work effectively in your project. Keep it concise and focused on what matters for day-to-day development.
+
+## Recommended Template
+
+```markdown
+# Project Name
+
+## Overview
+One paragraph on what this project does.
+
+## Tech Stack
+- Framework: Rails 7.2
+- Database: PostgreSQL
+
+## Key Patterns
+- Service objects in app/services/
+- Result pattern for service returns
+
+## Testing
+- RSpec with FactoryBot
+- Run tests: `bin/rspec`
+```
+
+## Guidelines
+
+- **Keep it short** - Claude reads this every session. Long files waste context.
+- **Focus on conventions** - Document patterns that aren't obvious from the code itself.
+- **Include run commands** - How to run tests, start the server, run migrations.
+- **Skip the obvious** - Don't document standard framework conventions.

--- a/tips/use-subagents-for-focused-tasks.md
+++ b/tips/use-subagents-for-focused-tasks.md
@@ -1,0 +1,19 @@
+# Use Subagents for Focused Tasks
+
+When Claude spawns subagents, each one gets focused context. This keeps the main conversation clean and lets specialized work happen in parallel.
+
+## When to Use Subagents
+
+- **Security review** - Let Claude spawn a security-focused subagent to analyze your code for vulnerabilities.
+- **Code review** - Multiple specialized reviewers can work in parallel, each focusing on a different aspect (architecture, testing, performance).
+- **Research** - Subagents can explore the codebase or search for information without cluttering your main context.
+
+## How It Works
+
+Claude automatically uses subagents when appropriate. You can also prompt it directly:
+
+```
+Review this PR with separate subagents for security, testing, and architecture.
+```
+
+The [parallel-code-review](../plugins/parallel-code-review/README.md) skill is built around this pattern, spawning multiple reviewers that each focus on a specific concern.

--- a/tips/worktrees-for-parallel-agents.md
+++ b/tips/worktrees-for-parallel-agents.md
@@ -1,0 +1,47 @@
+# Use Worktrees for Parallel Agents
+
+Git worktrees let you run multiple Claude Code agents on the same codebase without conflicts.
+
+## The Problem
+
+If you run 2+ agents on the same repo, you get:
+- Unrelated changes in one branch
+- Agents overwriting each other's files
+- Test suites colliding on the same database
+
+## The Solution
+
+Each agent gets its own worktree via `claude --worktree`.
+
+**But wait** - your app won't run because `.env` and other secrets don't copy over. And if both agents run tests, they'll fight over the same database.
+
+## Automate It with Worktree Sync
+
+The [worktree-sync](../plugins/worktree-sync/README.md) plugin uses Claude Code's `WorktreeCreate` hook to automatically symlink gitignored files into new worktrees.
+
+### Setup
+
+1. Add a `.worktreeinclude` to your project root:
+```
+.env
+.env.local
+config/master.key
+```
+
+2. Configure the hooks in `.claude/settings.json` (see [setup instructions](../plugins/worktree-sync/README.md#setup))
+
+3. Run `claude --worktree` and your secrets are there automatically.
+
+Only files matching both `.worktreeinclude` AND `.gitignore` are synced. You can also configure a post-create script via `.worktreesync` for project-specific setup like database isolation.
+
+## Rails Apps
+
+There's a standalone setup script for manual worktree creation:
+
+```bash
+./scripts/setup-rails-worktree.sh feature-branch
+```
+
+Get the script: [scripts/setup-rails-worktree.sh](../scripts/setup-rails-worktree.sh) | [example.worktreeinclude](../scripts/example.worktreeinclude) | [Git Worktrees Cheat Sheet](https://www.damiangalarza.com/downloads/git-worktree-cheatsheet?utm_source=github&utm_medium=readme&utm_campaign=claude-code-workflows)
+
+The `rails-toolkit` plugin also includes `/rails-toolkit:linear-worktree` which automates this with Linear issue context.


### PR DESCRIPTION
Move inline tips & tricks content from README.md into individual
pages under tips/, replacing them with a linked table that matches
the format used for Skills, Agents, Hooks, and Bundles.

https://claude.ai/code/session_01KukapoUFfZrSe4FuttUN6u