### PR TITLE
Add video introduction link to Claudit plugin documentation

### DIFF
--- a/tips/plugins-worth-installing.md
+++ b/tips/plugins-worth-installing.md
@@ -4,7 +4,7 @@ Plugins extend Claude Code with specialized behaviors, audit tools, and domain e
 
 ## Recommended Plugins
 
-1. **[Claudit](https://github.com/acostanzo/quickstop/tree/main/plugins/claudit)** - Configuration auditor that evaluates your Claude Code setup against Anthropic's best practices. Scores six categories (over-engineering, CLAUDE.md quality, security, MCP config, plugin health, context efficiency) with letter grades and actionable recommendations. Uses subagents to fetch current docs before auditing, so results stay up to date.
+1. **[Claudit](https://github.com/acostanzo/quickstop/tree/main/plugins/claudit)** - Configuration auditor that evaluates your Claude Code setup against Anthropic's best practices. Scores six categories (over-engineering, CLAUDE.md quality, security, MCP config, plugin health, context efficiency) with letter grades and actionable recommendations. Uses subagents to fetch current docs before auditing, so results stay up to date. [Watch video introduction](https://youtu.be/HJvtgldlzDI?si=xHfXaGRZ8Bt7GpHQ)
 
 ## Setup
 


### PR DESCRIPTION
## Summary
Added a link to a video introduction for the Claudit plugin in the recommended plugins documentation.

## Changes
- Added a video introduction link to the Claudit plugin description that directs users to a YouTube video walkthrough of the plugin's features and usage

## Details
This enhancement helps users quickly understand what Claudit does by providing a visual introduction alongside the text description. The video link is appended to the existing plugin description to maintain the current documentation structure while offering an additional learning resource.

https://claude.ai/code/session_011EHi6hfmkcg3hwk6mexkZC