### PR TITLE
feat: add codebase-readiness plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -46,6 +46,12 @@
       "source": "./plugins/gridfinity-planner",
       "description": "Plan and design gridfinity baseplates for 3D printing with optimal grid layouts",
       "version": "1.1.0"
+    },
+    {
+      "name": "codebase-readiness",
+      "source": "./plugins/codebase-readiness",
+      "description": "Score your codebase's readiness for autonomous AI agent work across 8 dimensions, framed around the Stripe benchmark of 1k+ AI-generated PRs per week",
+      "version": "1.3.0"
     }
   ]
 }

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -63,9 +63,11 @@ npx skills add dgalarza/claude-code-workflows --skill "tdd-workflow"
 | Bundle | Description |
 |--------|-------------|
 | `rails-toolkit` | Complete Rails dev workflow (agents + commands + skills) |
+| `codebase-readiness` | Agent-Ready Codebase Assessment — scored report across 8 dimensions |
 
 ```bash
 /plugin install rails-toolkit@dgalarza-workflows
+/plugin install codebase-readiness@dgalarza-workflows
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -23,10 +23,28 @@ See [INSTALL.md](INSTALL.md) for full details.
 
 ---
 
+## Featured: Agent-Ready Codebase Assessment
+
+**Does your codebase support AI agent work — or fight against it?**
+
+The [Codebase Readiness](plugins/codebase-readiness/README.md) plugin scores your repo across 8 dimensions (0-100) and tells you exactly where you stand — framed against teams shipping 1,000+ AI-generated PRs per week.
+
+```bash
+/plugin install codebase-readiness@dgalarza-workflows
+/codebase-readiness
+```
+
+You get a band rating (Agent-Ready → Not Agent-Ready), a concrete improvement roadmap, and an optional saved report to share with your team. Not opinions — evidence gathered from your actual codebase.
+
+[Learn more →](plugins/codebase-readiness/README.md) | [Want help improving your score?](https://www.damiangalarza.com/services/ai-enablement/?utm_source=github&utm_medium=readme&utm_campaign=claude-code-workflows)
+
+---
+
 ## Skills
 
 | Skill | Description |
 |-------|-------------|
+| [Codebase Readiness](plugins/codebase-readiness/README.md) | Score your repo's readiness for autonomous AI agent work |
 | [TDD Workflow](plugins/tdd-workflow/README.md) | Test-driven development, one test at a time |
 | [Conventional Commits](plugins/conventional-commits/README.md) | Structured commit messages |
 | [Parallel Code Review](plugins/parallel-code-review/README.md) | Multi-agent code reviews |

--- a/plugins/codebase-readiness/.claude-plugin/plugin.json
+++ b/plugins/codebase-readiness/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "codebase-readiness",
+  "version": "1.3.0",
+  "description": "Agent-Ready Codebase Assessment — scores your codebase across 8 dimensions and generates an actionable improvement roadmap framed around the Stripe AI benchmark",
+  "author": {
+    "name": "Damian Galarza",
+    "url": "https://www.damiangalarza.com"
+  },
+  "repository": "https://github.com/dgalarza/claude-code-workflows",
+  "license": "MIT",
+  "keywords": [
+    "ai",
+    "agents",
+    "assessment",
+    "code-quality",
+    "readiness",
+    "lead-magnet"
+  ]
+}

--- a/plugins/codebase-readiness/README.md
+++ b/plugins/codebase-readiness/README.md
@@ -1,0 +1,72 @@
+# Agent-Ready Codebase Assessment
+
+**Does your codebase support AI agent work — or fight against it?**
+
+This plugin runs a scored assessment of your repo across 8 dimensions and tells you exactly where you stand, framed against the benchmark of engineering teams shipping 1,000+ AI-generated pull requests per week.
+
+The result is a score (0-100), a band rating, and a concrete improvement roadmap. Not opinions — evidence gathered from your actual codebase.
+
+## Installation
+
+```
+/plugin marketplace add dgalarza/claude-code-workflows
+/plugin install codebase-readiness@dgalarza-workflows
+```
+
+## Usage
+
+From any project directory:
+
+```
+/codebase-readiness
+```
+
+The assessment spawns 4 parallel agents, scores all 8 dimensions using language-specific rubrics, and produces a full report. Takes about 10 minutes. Optionally saves the report as `AGENT_READY_ASSESSMENT.md` for sharing with your team.
+
+## Score Bands
+
+| Score  | Band             | What it means                                  |
+|--------|------------------|------------------------------------------------|
+| 85–100 | Agent-Ready      | Supports autonomous agent work                 |
+| 70–84  | Agent-Assisted   | Agents work well with human oversight          |
+| 50–69  | Agent-Supervised | Agents need heavy review before merging        |
+| 30–49  | Agent-Caution    | Foundational improvements needed first         |
+| 0–29   | Not Agent-Ready  | Significant investment required                |
+
+## What Gets Scored
+
+8 dimensions, weighted by language (dynamic languages like Ruby and Python weight tests higher; static languages like TypeScript and Go weight type safety higher):
+
+| Dimension                 | What it measures                                                        |
+|---------------------------|-------------------------------------------------------------------------|
+| Test Foundation           | Coverage, quality, test-to-code ratio, mutation testing                 |
+| Documentation & Context   | CLAUDE.md, ARCHITECTURE.md, ADRs, topic docs                           |
+| Code Clarity              | File size, naming, filesystem as interface, catch-all directories       |
+| Architecture Clarity      | Domain boundary visibility in the file tree, not just conceptual DDD    |
+| Type Safety               | Strict types, semantic type names, database-level invariants            |
+| Consistency & Conventions | Linting, formatting, custom architectural linters                       |
+| Feedback Loops            | CI speed, ephemeral environments, parallel dev capability               |
+| Change Safety             | Coupling, test isolation, PR size patterns                              |
+
+## Architecture
+
+The skill uses a **reference file pattern** for extensibility:
+
+- **Dimension files** (`references/dimensions/`) define *what* to assess and *how* to score — the methodology. These are language-agnostic and rarely change.
+- **Language files** (`references/languages/`) carry all language-specific tooling, commands, and scoring criteria. Adding support for a new language means adding one file.
+
+During assessment, the orchestrator detects the primary language, loads the appropriate reference files, and composes prompts for 4 general-purpose agents that run in parallel. Each agent receives the relevant dimension guides plus the full language file.
+
+## Why the Score Matters
+
+The best AI-assisted engineering teams don't just have good prompts — they have codebases that make agent output cheaply verifiable. Fast CI, strict types, comprehensive tests, clear documentation: these are what let agents iterate quickly without constant human review.
+
+The score measures how well your codebase satisfies that condition. The improvement roadmap tells you what to fix first.
+
+Benchmarks show agentic coding can deliver 20x+ productivity — but only when the setup is right. This assessment tells you where your setup stands.
+
+## Want Help Improving Your Score?
+
+Built by [Damian Galarza](https://www.damiangalarza.com), a Claude Code specialist who helps engineering teams close the gap between having AI tools and actually using them well.
+
+If your assessment surfaces gaps you want to fix faster, the [AI Workflow Enablement Program](https://www.damiangalarza.com/services/ai-enablement/) is a structured engagement that works through exactly this.

--- a/plugins/codebase-readiness/skills/codebase-readiness/SKILL.md
+++ b/plugins/codebase-readiness/skills/codebase-readiness/SKILL.md
@@ -1,0 +1,452 @@
+---
+name: codebase-readiness
+description: Run an Agent-Ready Codebase Assessment to score your codebase across 8 dimensions using parallel specialized agents. Produces a weighted score (0-100) with a band rating (Agent-Ready → Not Agent-Ready), improvement roadmap, and optional saved report. Framed around the Stripe benchmark of 1,000+ AI-generated PRs per week. Use when a developer or CTO wants to understand how ready their codebase is for autonomous AI agent work.
+---
+
+# Codebase Readiness Assessment
+
+You are running an **Agent-Ready Codebase Assessment** — a scored evaluation of how well this codebase supports autonomous AI agent work, framed against the Stripe benchmark of 1,000+ AI-generated pull requests per week.
+
+Work through the following phases sequentially.
+
+---
+
+## Phase 1: Codebase Reconnaissance
+
+Run the following commands to build a **Codebase Snapshot** before launching assessment agents. Do this directly — no agent needed.
+
+```bash
+# Project name
+basename $(pwd)
+
+# Language/framework detection
+ls package.json Gemfile pyproject.toml go.mod requirements.txt pom.xml build.sbt 2>/dev/null
+cat package.json 2>/dev/null | grep '"name"\|"main"\|"scripts"' | head -5
+head -5 Gemfile 2>/dev/null
+head -5 pyproject.toml 2>/dev/null
+head -3 go.mod 2>/dev/null
+head -5 build.sbt 2>/dev/null
+
+# Size metrics
+git rev-list --count HEAD 2>/dev/null || echo "Not a git repo or no commits"
+git shortlog -sn HEAD 2>/dev/null | wc -l
+find . -name "*.rb" -o -name "*.ts" -o -name "*.tsx" -o -name "*.py" -o -name "*.go" -o -name "*.js" -o -name "*.scala" -o -name "*.java" 2>/dev/null \
+  | grep -v node_modules | grep -v .git | grep -v vendor | grep -v target | grep -v spec | grep -v test | wc -l
+
+# Test file ratio
+find . -name "*_spec*" -o -name "*_test*" -o -name "*.spec.*" -o -name "*.test.*" -o -name "test_*.py" -o -name "*Spec.scala" -o -name "*Test.scala" -o -name "*Suite.scala" 2>/dev/null \
+  | grep -v node_modules | grep -v .git | grep -v target | wc -l
+
+# CI/CD presence
+ls .github/workflows/ .circleci/ .buildkite/ .gitlab-ci.yml 2>/dev/null
+
+# CLAUDE.md
+find . -name "CLAUDE.md" 2>/dev/null | grep -v node_modules | grep -v .git
+find . -name "CLAUDE.md" -exec wc -l {} \; 2>/dev/null | grep -v node_modules
+
+# Linting/formatting configs
+ls .eslintrc* .rubocop.yml .flake8 ruff.toml .golangci.yml .prettierrc* .scalafmt.conf .scalafix.conf 2>/dev/null
+
+# README
+ls README.md README.rst README.txt 2>/dev/null
+wc -l README.md 2>/dev/null
+```
+
+After running these commands, output a formatted **Codebase Snapshot**:
+
+```
+## Codebase Snapshot: [Project Name]
+
+- **Primary language/framework**: [detected]
+- **Language tier**: [statically-typed | dynamically-typed | gradually-typed]
+  - Statically-typed: TypeScript, Go, Java, Scala, Rust, C#, Kotlin
+  - Dynamically-typed: Ruby, Python (unannotated), JavaScript/Node.js
+  - Gradually-typed: Python with mypy/Pydantic, TypeScript with strict:false
+- **Commit count**: [X]
+- **Contributors**: [X]
+- **Source files**: [X]
+- **Test files**: [X] (ratio: X%)
+- **CI/CD**: [platform(s) found or none]
+- **CLAUDE.md**: [present at path, X lines / absent]
+- **Linting config**: [tools found or none]
+- **README**: [present, X lines / absent]
+```
+
+Determine `PRIMARY_LANGUAGE` (ruby, python, typescript, javascript, go, java, or scala) and `LANGUAGE_TIER` (statically-typed, dynamically-typed, or gradually-typed) from the snapshot. These values drive which language reference file to load.
+
+---
+
+## Phase 2: Launch 4 Assessment Agents in Parallel
+
+### Prompt Composition
+
+Each agent receives a composed prompt built from reference files. The process:
+
+1. **Read the language file** — `references/languages/{PRIMARY_LANGUAGE}.md` (include the entire file in each agent prompt)
+2. **Read the dimension files** — each agent gets its relevant dimension files from `references/dimensions/`
+3. **Compose the prompt** — role preamble + codebase snapshot + dimension content + language content + output instructions
+
+Use the Read tool to load each reference file, then include the content inline in the agent prompts.
+
+### Agent Prompts
+
+Send a **single message** with **4 Agent tool calls** (subagent_type: `general-purpose`) to launch all agents simultaneously. Each agent gets the following composed prompt structure:
+
+---
+
+**Agent 1: Test & CI Agent**
+
+Dimension files to read and include:
+- `references/dimensions/test-foundation.md`
+- `references/dimensions/feedback-loops.md`
+
+Prompt:
+```
+You are a senior engineering consultant specializing in test infrastructure and developer feedback loops. Your role is to assess how well a codebase's testing and CI/CD setup supports autonomous AI agent work.
+
+Here is the Codebase Snapshot gathered by the orchestrator:
+
+[INSERT FULL CODEBASE SNAPSHOT]
+
+LANGUAGE_TIER: [static | dynamic | gradual]
+PRIMARY_LANGUAGE: [Ruby | Python | TypeScript | Go | etc.]
+
+## Assessment Instructions
+
+Use the dimension guides and language-specific criteria below to assess two dimensions: **Test Foundation** and **Feedback Loops**. Run the evidence-gathering commands from both the dimension guides and the language file to collect data. Score each dimension 0-100 following the scoring bands, then apply any score modifiers.
+
+### Dimension Guide: Test Foundation
+
+[INSERT CONTENT OF references/dimensions/test-foundation.md]
+
+### Dimension Guide: Feedback Loops
+
+[INSERT CONTENT OF references/dimensions/feedback-loops.md]
+
+### Language-Specific Criteria
+
+[INSERT CONTENT OF references/languages/{PRIMARY_LANGUAGE}.md]
+
+Return the full scored assessment for both dimensions in the output format specified in each dimension guide. Be specific — reference actual files, counts, and statistics.
+```
+
+---
+
+**Agent 2: Documentation Agent**
+
+Dimension files to read and include:
+- `references/dimensions/documentation.md`
+
+Prompt:
+```
+You are a senior engineering consultant specializing in developer experience and knowledge management. Your role is to assess how well a codebase's documentation enables AI agents to work autonomously without constant human clarification.
+
+Here is the Codebase Snapshot gathered by the orchestrator:
+
+[INSERT FULL CODEBASE SNAPSHOT]
+
+LANGUAGE_TIER: [static | dynamic | gradual]
+PRIMARY_LANGUAGE: [Ruby | Python | TypeScript | Go | etc.]
+
+## Assessment Instructions
+
+Use the dimension guide and language-specific criteria below to assess one dimension: **Documentation & Context**. Run the evidence-gathering commands to collect data. Score 0-100 following the scoring bands.
+
+### Dimension Guide: Documentation & Context
+
+[INSERT CONTENT OF references/dimensions/documentation.md]
+
+### Language-Specific Criteria
+
+[INSERT CONTENT OF references/languages/{PRIMARY_LANGUAGE}.md]
+
+Return the full scored assessment in the output format specified in the dimension guide. Be specific — reference actual files found. CLAUDE.md is the most important artifact for agent-readiness — give it special attention.
+```
+
+---
+
+**Agent 3: Code Quality Agent**
+
+Dimension files to read and include:
+- `references/dimensions/code-clarity.md`
+- `references/dimensions/consistency.md`
+
+Prompt:
+```
+You are a senior engineering consultant specializing in code quality and developer tooling. Your role is to assess how navigable and consistent a codebase is for AI agents — agents perform better in codebases with small, focused files and enforced conventions.
+
+Here is the Codebase Snapshot gathered by the orchestrator:
+
+[INSERT FULL CODEBASE SNAPSHOT]
+
+LANGUAGE_TIER: [static | dynamic | gradual]
+PRIMARY_LANGUAGE: [Ruby | Python | TypeScript | Go | etc.]
+
+## Assessment Instructions
+
+Use the dimension guides and language-specific criteria below to assess two dimensions: **Code Clarity** and **Consistency & Conventions**. Run the evidence-gathering commands from both the dimension guides and the language file to collect data. Score each dimension 0-100 following the scoring bands.
+
+### Dimension Guide: Code Clarity
+
+[INSERT CONTENT OF references/dimensions/code-clarity.md]
+
+### Dimension Guide: Consistency & Conventions
+
+[INSERT CONTENT OF references/dimensions/consistency.md]
+
+### Language-Specific Criteria
+
+[INSERT CONTENT OF references/languages/{PRIMARY_LANGUAGE}.md]
+
+Return the full scored assessment for both dimensions in the output format specified in each dimension guide. Be specific — reference actual files and line counts.
+```
+
+---
+
+**Agent 4: Architecture Agent**
+
+Dimension files to read and include:
+- `references/dimensions/type-safety.md`
+- `references/dimensions/architecture-clarity.md`
+- `references/dimensions/change-safety.md`
+
+Prompt:
+```
+You are a senior engineering consultant specializing in software architecture and developer safety systems. Your role is to assess how safely and predictably AI agents can modify a codebase — the guard rails that prevent agent mistakes vary by language: type systems for statically-typed languages, contract/test systems for dynamically-typed ones.
+
+Here is the Codebase Snapshot gathered by the orchestrator:
+
+[INSERT FULL CODEBASE SNAPSHOT]
+
+LANGUAGE_TIER: [static | dynamic | gradual]
+PRIMARY_LANGUAGE: [Ruby | Python | TypeScript | Go | etc.]
+
+## Assessment Instructions
+
+Use the dimension guides and language-specific criteria below to assess three dimensions: **Type Safety**, **Architecture Clarity**, and **Change Safety**. Run the evidence-gathering commands from both the dimension guides and the language file to collect data. Score each dimension 0-100 following the scoring bands, then apply any score modifiers. Apply the language-appropriate Type Safety rubric based on LANGUAGE_TIER.
+
+### Dimension Guide: Type Safety
+
+[INSERT CONTENT OF references/dimensions/type-safety.md]
+
+### Dimension Guide: Architecture Clarity
+
+[INSERT CONTENT OF references/dimensions/architecture-clarity.md]
+
+### Dimension Guide: Change Safety
+
+[INSERT CONTENT OF references/dimensions/change-safety.md]
+
+### Language-Specific Criteria
+
+[INSERT CONTENT OF references/languages/{PRIMARY_LANGUAGE}.md]
+
+Return the full scored assessment for all three dimensions in the output format specified in each dimension guide. Be specific — reference actual files, line counts, and git statistics.
+```
+
+---
+
+Wait for all 4 agents to complete before proceeding.
+
+---
+
+## Phase 3: Score Calculation
+
+Weights are **language-adaptive**. Select the appropriate table based on `LANGUAGE_TIER` from the Codebase Snapshot.
+
+### Dynamically-typed languages (Ruby, Python, JavaScript)
+
+In dynamic languages, tests are the type system. Test Foundation carries more weight; Type Safety reflects contracts and interface clarity, not a type checker.
+
+| Dimension                 | Weight | Agent Score | Weighted |
+|---------------------------|--------|-------------|----------|
+| Test Foundation           | 25%    | XX/100      | XX       |
+| Documentation & Context   | 15%    | XX/100      | XX       |
+| Code Clarity              | 15%    | XX/100      | XX       |
+| Architecture Clarity      | 15%    | XX/100      | XX       |
+| Feedback Loops            | 10%    | XX/100      | XX       |
+| Type Safety*              | 10%    | XX/100      | XX       |
+| Consistency & Conventions | 5%     | XX/100      | XX       |
+| Change Safety             | 5%     | XX/100      | XX       |
+
+*Type Safety for dynamic languages = contracts (dry-rb, Pydantic), ActiveRecord validations, Result pattern consistency. NOT penalized for absence of a type checker.
+
+### Statically-typed languages (TypeScript, Go, Java, Scala, Rust)
+
+| Dimension                 | Weight | Agent Score | Weighted |
+|---------------------------|--------|-------------|----------|
+| Type Safety               | 20%    | XX/100      | XX       |
+| Test Foundation           | 15%    | XX/100      | XX       |
+| Documentation & Context   | 15%    | XX/100      | XX       |
+| Code Clarity              | 15%    | XX/100      | XX       |
+| Architecture Clarity      | 15%    | XX/100      | XX       |
+| Feedback Loops            | 10%    | XX/100      | XX       |
+| Consistency & Conventions | 5%     | XX/100      | XX       |
+| Change Safety             | 5%     | XX/100      | XX       |
+
+**Overall Score** = sum of (agent score × weight)
+
+**Score Bands:**
+- **85-100**: Agent-Ready — codebase supports autonomous agent work
+- **70-84**: Agent-Assisted — agents work well with human oversight
+- **50-69**: Agent-Supervised — agents need heavy review before merging
+- **30-49**: Agent-Caution — foundational improvements needed first
+- **0-29**: Not Agent-Ready — significant investment required before agent work
+
+---
+
+## Phase 4: Report Assembly
+
+Assemble and output the full report:
+
+```markdown
+# Agent-Ready Assessment: [Project Name]
+
+## Overall Agent-Ready Score: XX/100
+**Rating: [Band Name]**
+
+[2-sentence interpretation — e.g., "This codebase can support AI agent work with human oversight on most changes. The test foundation and type system provide reasonable guard rails, but documentation gaps will cause agents to make incorrect assumptions about business intent."]
+
+### Score Breakdown
+
+| Dimension                 | Weight | Score   | Weighted |
+|---------------------------|--------|---------|----------|
+| Test Foundation           | 20%    | XX/100  | XX.X     |
+| Documentation & Context   | 15%    | XX/100  | XX.X     |
+| Code Clarity              | 15%    | XX/100  | XX.X     |
+| Type Safety               | 15%    | XX/100  | XX.X     |
+| Architecture Clarity      | 15%    | XX/100  | XX.X     |
+| Consistency & Conventions | 10%    | XX/100  | XX.X     |
+| Feedback Loops            | 5%     | XX/100  | XX.X     |
+| Change Safety             | 5%     | XX/100  | XX.X     |
+| **TOTAL**                 | 100%   |         | **XX/100** |
+
+---
+
+## Language Context: [Primary Language]
+
+> **For dynamically-typed languages (Ruby, Python, JavaScript) only — omit for TypeScript/Go/Java.**
+
+This codebase is written in **[Language]**, a dynamically-typed language. The scoring framework adapts for this:
+
+| Signal | [Language] equivalent |
+|--------|----------------------|
+| Type Safety (10%) | Contract systems ([dry-rb/Pydantic/etc.]), validated interfaces, Result pattern |
+| Test Foundation (25%) | [Language]'s primary safety mechanism — comprehensive tests catch what type checkers catch in TypeScript |
+
+A **Type Safety score of 30-50 paired with a Test Foundation score of 75+** is a healthy Ruby/Python codebase — not a gap. The combined 35% weight (10% + 25%) provides the same safety signal as TypeScript's Type Safety at 20%.
+
+---
+
+## The Stripe Benchmark
+
+Stripe's engineering team merged 1,000+ AI-generated pull requests in a single week. This is possible because Stripe's codebase satisfies what researchers call the **asymmetry of verification**: generating a PR is hard, but *verifying* one — with fast CI, strict types, and comprehensive tests — takes minutes. Every dimension in this assessment measures how well your codebase satisfies that asymmetry.
+
+The goal is to make agent output cheaply verifiable: the cost of a wrong answer is low, the feedback loop is fast, and the automated verification layer catches mistakes before humans need to. A score of 70+ means that condition is largely met. Below 50 means the verification infrastructure needs to be built before agents can work reliably.
+
+---
+
+## Critical Findings
+[List any dimensions scoring below 40, with the specific gap and why it blocks agent work]
+
+---
+
+## Verification Cost Profile
+
+> How expensive is it to confirm an agent's change is correct in this codebase?
+
+| Signal | Status | What it means |
+|--------|--------|----------------|
+| Tests run in < 10 min | ✓ / ✗ | Fast verification enables agent iteration cycles |
+| Security scanning automated | ✓ / ✗ | Non-functional correctness covered without manual review |
+| Property-based tests present | ✓ / ✗ | Oracle generates adversarial inputs, not just happy paths |
+| Reproducible dev state (seeds/factories) | ✓ / ✗ | Agents can set up verifiable scenarios independently |
+| Coverage reported on PRs | ✓ / ✗ | Regression signal visible before human review |
+
+**Verification bottleneck:** [The single biggest barrier to confirming agent-produced changes — e.g., "No security scanning means agent-introduced vulnerabilities only surface in manual review or production" or "45-min CI limits agents to ~10 verification cycles per day"]
+
+---
+
+## Improvement Roadmap
+
+### Quick Wins (1-2 days each)
+[Consolidated list from all agent reports — highest-impact, lowest-effort items]
+
+### High-Value Investments (1-4 weeks each)
+[Consolidated list from all agent reports — significant improvements requiring dedicated effort]
+
+### Long-Term Architecture (Ongoing)
+[Strategic improvements that require sustained investment]
+
+---
+
+## Want Help Moving the Needle?
+
+This assessment was built by [Damian Galarza](https://www.damiangalarza.com) — a Claude Code specialist who helps engineering teams close the gap between having AI tools and actually using them well.
+
+If your score surfaced gaps you want to fix, the **AI Workflow Enablement Program** is a structured 3–8 week engagement that works through exactly this: codebase readiness, team conventions, shared skills, and workshops built on your actual codebase.
+
+**[See the full program →](https://www.damiangalarza.com/services/ai-enablement/)**
+
+---
+
+## Dimension Details
+
+[Insert full agent reports for all 8 dimensions here, grouped by agent]
+
+### Test Foundation & Feedback Loops
+[Test & CI agent full report]
+
+### Documentation & Context
+[Documentation agent full report]
+
+### Code Clarity & Consistency
+[Code Quality agent full report]
+
+### Type Safety, Architecture & Change Safety
+[Architecture agent full report]
+
+---
+
+## What "Agent-Ready" Means
+
+AI agent work doesn't eliminate verification — it relocates it. Before agents, developers split time between writing, reading, and checking code. With agents, writing is offloaded. But every line an agent produces still needs to be verified against human intent, either by automated systems or by humans reading code.
+
+An agent-ready codebase maximizes automated verification and minimizes the cost per change:
+
+- **Tests are the oracle** — when an agent makes a change, the test suite tells it immediately whether that change matches intent. Without tests, every agent change requires a human to read and reason about correctness manually — which destroys scalability. A noisy oracle (flaky tests, heavily mocked suites) is nearly as bad as no tests.
+- **Type systems reduce verifier noise** — a type-checked build that passes is a higher-confidence signal than an untyped build that passes. Types convert silent runtime failures into loud compile-time failures, so agent mistakes are caught before a human ever reviews them.
+- **Documentation makes intent verifiable** — CLAUDE.md and ADRs give agents the context to produce changes that match business intent, not just syntactic correctness. Without documented intent, an agent's change can pass every automated check and still be wrong in ways only a human reviewer can catch.
+- **Small files bound the verification surface** — when a change is contained to one focused file, a test failure is attributable and precise. Large files and high coupling produce noisy feedback: a failure could be caused by any of a dozen interacting concerns.
+- **Fast feedback enables iteration** — a 45-minute CI pipeline limits agents to ~10 verification cycles per day. A 5-minute pipeline enables ~100. Pipeline speed is a structural prerequisite for agent work at scale, not a convenience.
+- **Security and vulnerability scanning extends coverage** — functional tests verify behavior; security scanners verify a different correctness dimension that agents can silently violate.
+
+Each point in the Improvement Roadmap raises your verification limit — reducing manual review burden while increasing confidence in every agent-produced change.
+
+---
+*Generated by codebase-readiness skill — claude-code-workflows*
+```
+
+---
+
+## Phase 5: Offer to Save Report
+
+After presenting the report, ask:
+
+> "Would you like me to save this assessment as `AGENT_READY_ASSESSMENT.md` in the project root? It can serve as a baseline for tracking improvements over time and is useful for sharing with your team."
+
+If the user confirms, write the full report to `AGENT_READY_ASSESSMENT.md` in the current directory.
+
+---
+
+## Phase 6: CI Integration Recommendation
+
+After saving (or if the user declines), mention:
+
+> **For continuous tracking:** Consider adding [`btar`](https://github.com/btahq/btar) to your CI pipeline. It provides fast, deterministic measurement of your verification infrastructure (type errors, lint violations, test coverage) and can gate PRs when scores regress. This assessment gives you a strategic baseline; btar gives you daily CI enforcement of the most critical metrics.
+>
+> ```bash
+> npm install -g btar
+> btar analyze .          # Quick score: types + lint + coverage
+> btar context generate agents-md  # Auto-generates AGENTS.md with your build/test commands
+> ```

--- a/plugins/codebase-readiness/skills/codebase-readiness/references/dimensions/architecture-clarity.md
+++ b/plugins/codebase-readiness/skills/codebase-readiness/references/dimensions/architecture-clarity.md
@@ -1,0 +1,108 @@
+# Architecture Clarity
+
+## Why This Matters for Agent Readiness
+
+Architecture clarity determines whether an agent can understand where to make a change without reading the entire codebase. When domain boundaries are visible in the filesystem, an agent can reason about one vertical slice at a time, apply domain-specific instructions, and scope its changes confidently. Without this clarity, every change requires global understanding — which exceeds practical context limits and increases the risk of unintended cross-domain side effects.
+
+## What to Examine
+
+- **Domain boundary visibility**: The PRIMARY signal. Are business domains expressed as distinct filesystem subtrees, not just conceptual groupings?
+  - When boundaries are NOT in the filesystem, agents cannot: reason about one vertical in isolation, benefit from domain-specific CLAUDE.md files, apply scoped skills, or limit blast radius
+  - Good visibility means: each domain lives in its own subtree, cross-domain dependencies are explicit, and each domain has a natural home for domain-specific documentation
+- **Domain grouping consistency**: Within domain directories, do files follow consistent naming and organization? Or are some files at the root level while others are properly nested?
+- **Service/domain layer presence**: Is business logic separated from transport/presentation concerns (thin controllers, service objects, use cases, interactors)?
+- **God objects / large shared files**: Are there oversized files that concentrate cross-cutting logic, making it impossible to reason about one domain in isolation?
+- **Nested CLAUDE.md files**: The presence of domain-scoped CLAUDE.md files signals intentional boundary design for agent consumption
+- **Dependency explicitness**: Can you trace which domains depend on which by examining imports/requires, or are dependencies implicit and global?
+
+## Evidence-Gathering Commands
+
+```bash
+# Top-level directory structure
+ls -la
+find . -maxdepth 3 -type d 2>/dev/null | grep -v node_modules | grep -v .git | grep -v vendor | grep -v ".bundle" | sort | head -50
+
+# Domain/vertical directories
+find . -maxdepth 4 -type d \( -name "domain" -o -name "domains" -o -name "bounded_contexts" -o -name "contexts" \) 2>/dev/null | grep -v node_modules | grep -v .git
+
+# Service layer
+find . -type d \( -name "services" -o -name "domain" -o -name "use_cases" -o -name "interactors" \) 2>/dev/null | grep -v node_modules | grep -v .git
+
+# God objects / large shared files
+find . -name "*.rb" -o -name "*.ts" -o -name "*.tsx" -o -name "*.py" -o -name "*.go" -o -name "*.js" -o -name "*.scala" -o -name "*.java" 2>/dev/null \
+  | grep -v node_modules | grep -v .git | grep -v vendor | grep -v spec | grep -v test \
+  | xargs wc -l 2>/dev/null | sort -rn | head -15
+
+# Nested CLAUDE.md files (signals intentional domain scoping)
+find . -name "CLAUDE.md" 2>/dev/null | grep -v node_modules | grep -v .git
+
+# Dependency management files
+ls package.json Gemfile requirements*.txt pyproject.toml go.mod 2>/dev/null
+```
+
+### Domain Grouping Consistency Check
+
+For each domain directory that groups source files, check whether files are properly nested or leaking to the root level:
+
+```bash
+# Pick a representative domain source directory (e.g., app/services, src/domain)
+SOURCE_DIR="app/services"  # adjust per codebase
+
+if [ -d "$SOURCE_DIR" ]; then
+  TOTAL=$(find "$SOURCE_DIR" -type f 2>/dev/null | wc -l)
+  ROOT_FILES=$(find "$SOURCE_DIR" -maxdepth 1 -type f 2>/dev/null | wc -l)
+  SUBDIR_FILES=$(find "$SOURCE_DIR" -mindepth 2 -type f 2>/dev/null | wc -l)
+  echo "Total files: $TOTAL"
+  echo "Root-level files (not in subdirectory): $ROOT_FILES"
+  echo "Files in subdirectories: $SUBDIR_FILES"
+  if [ "$TOTAL" -gt 0 ]; then
+    PCT=$(( ROOT_FILES * 100 / TOTAL ))
+    echo "Root-level leakage: ${PCT}%"
+  fi
+fi
+```
+
+## Scoring Bands
+
+- **0-20**: Business logic lives in controllers/views/handlers with no separation. No service or domain layer. Verticals are fully intermingled — changing one feature requires touching files across many directories with no clear grouping.
+- **21-40**: Some separation exists but is inconsistent. Multiple domains share the same models/services directories. Business logic partially extracted but no clear domain boundaries in the filesystem.
+- **41-60**: Service layer present, conventions partially followed. Domain subdirectories exist BUT are unreliable — more than 25% root-level leakage, inconsistent naming across layers. Agent can sometimes reason about one domain but must verify assumptions.
+- **61-80**: Clear service/domain layer with thin controllers. Domain subdirectories reliably used (less than 25% root leakage). Names align across layers. Agent can usually navigate to the right domain confidently.
+- **81-100**: Each domain is independently navigable in the file tree. Domains live in their own subtrees with explicit cross-domain dependencies. Each domain has a natural home for domain-specific CLAUDE.md. Agent can reason about a single domain without understanding the whole codebase.
+
+NOTE: For dimensions where scoring bands differ materially by language, these bands provide the general framing. The language file provides concrete criteria and tooling-specific thresholds.
+
+## Score Modifiers
+
+- **Nested CLAUDE.md files** present in domain directories: **+5**
+- **God files** (files >1000 lines of business logic) in shared directories: **-5 per god file** (up to -15)
+
+## Output Format
+
+```markdown
+## Architecture Clarity Assessment
+
+**Score: XX/100**
+
+### Evidence
+- Directory structure: [flat / layered / domain-organized]
+- Domain boundaries in filesystem: [yes / partial / no]
+- Domain grouping consistency: [XX% root-level leakage]
+- Service/domain layer: [present / partial / absent]
+- God objects found: [count, with largest listed]
+- Nested CLAUDE.md files: [count, locations]
+- Cross-domain dependency explicitness: [explicit / implicit / mixed]
+
+### Strengths
+- [What's working well]
+
+### Gaps
+- [What's missing or weak]
+
+### Recommendations
+**Quick Wins (1-2 days):**
+- [Specific actionable item]
+
+**High-Value Investments (1-4 weeks):**
+- [Specific actionable item]
+```

--- a/plugins/codebase-readiness/skills/codebase-readiness/references/dimensions/change-safety.md
+++ b/plugins/codebase-readiness/skills/codebase-readiness/references/dimensions/change-safety.md
@@ -1,0 +1,85 @@
+# Change Safety
+
+## Why This Matters for Agent Readiness
+
+Change safety determines how contained the blast radius is when an agent makes a modification. Agents work best when changes are isolated — a fix in one module should not unexpectedly break behavior in another. Codebases with high coupling, no feature flags, and unsafe migration patterns force agents into a mode where every change carries disproportionate risk, reducing the scope of work they can safely perform autonomously.
+
+## What to Examine
+
+- **Coupling indicators via co-change analysis**: Which files frequently change together? High co-change frequency between unrelated modules signals hidden coupling that will trip up agents
+- **File churn**: Files that change most frequently represent both coupling risk and high-value targets for structural improvement
+- **Feature flag infrastructure**: Can new behavior be deployed behind flags, enabling safe incremental rollout? This is critical for agent-authored changes that may need quick rollback
+- **Database migration safety**: Are migrations reversible? Do they avoid destructive operations (dropping columns/tables) without safeguards? Are there patterns for safe schema changes (add-then-migrate-then-remove)?
+- **Module/service boundary clarity**: Are boundaries between components enforced (via interfaces, dependency injection, explicit APIs) or merely conventional?
+- **Rollback capability**: How quickly can a change be reverted if it causes problems?
+
+## Evidence-Gathering Commands
+
+```bash
+# Co-change analysis — files that frequently appear in the same commit
+git log --name-only --pretty=format: 2>/dev/null | grep -v "^$" | sort | uniq -c | sort -rn | head -20
+
+# Most frequently changed files (churn = coupling risk)
+git log --name-only --format="" 2>/dev/null | grep -v "^$" | sort | uniq -c | sort -rn | head -15
+
+# Feature flags (generic patterns across languages)
+grep -r "feature_flag\|feature_enabled\|featureFlag\|feature_toggle\|FeatureFlag\|FEATURE_" \
+  --include="*.rb" --include="*.ts" --include="*.tsx" --include="*.py" --include="*.go" --include="*.java" --include="*.js" \
+  . 2>/dev/null | grep -v node_modules | grep -v .git | grep -v spec | grep -v test | wc -l
+
+# Database migrations
+find . -name "*.rb" -path "*/migrations/*" -o -name "*.py" -path "*/migrations/*" -o -name "*.sql" 2>/dev/null | grep -v .git | wc -l
+
+# Migration safety patterns — look for irreversible operations
+grep -r "drop_table\|drop_column\|remove_column\|DROP TABLE\|DROP COLUMN\|rename_table\|rename_column" \
+  db/migrate/ migrations/ 2>/dev/null | grep -v .git | head -10
+
+# Rollback patterns
+grep -r "reversible\|def down\|def change\|rollback\|downgrade" db/migrate/ migrations/ 2>/dev/null | grep -v .git | wc -l
+```
+
+## Scoring Bands
+
+- **0-20**: High coupling evident (many files co-change across unrelated modules). No feature flags. Migrations are irreversible or unsafe. No clear module boundaries — changes routinely cascade.
+- **21-40**: Some module separation but co-change analysis reveals hidden coupling. Feature flags absent or ad-hoc. Migrations exist but safety patterns inconsistent. Rollback is manual and risky.
+- **41-60**: Moderate separation. Co-change mostly within related modules. Feature flag infrastructure exists but used inconsistently. Most migrations are reversible. Some boundary enforcement.
+- **61-80**: Good separation. Co-change largely confined to single modules. Feature flags used for significant changes. Safe migration patterns followed consistently. Clear module boundaries with some enforcement.
+- **81-100**: Excellent isolation. Co-change analysis confirms independent modules. Feature flag infrastructure mature and consistently used. All migrations follow safe patterns (add-migrate-remove). Module boundaries enforced via interfaces or explicit APIs. Rapid rollback capability.
+
+NOTE: For dimensions where scoring bands differ materially by language, these bands provide the general framing. The language file provides concrete criteria and tooling-specific thresholds.
+
+## Score Modifiers
+
+- **Feature flag infrastructure mature and actively used**: **+5**
+- **Safe migration patterns documented and enforced**: **+3**
+- **Circular dependencies detected between modules**: **-10**
+- **Top 5 most-changed files are all in shared/common directories**: **-5**
+
+## Output Format
+
+```markdown
+## Change Safety Assessment
+
+**Score: XX/100**
+
+### Evidence
+- Co-change coupling: [low / moderate / high — with top clusters listed]
+- Highest-churn files: [top 5 with change counts]
+- Feature flags: [mature / basic / absent — count of usages]
+- Migration safety: [safe patterns / mixed / unsafe]
+- Module boundaries: [enforced / conventional / absent]
+- Rollback capability: [rapid / manual / unknown]
+
+### Strengths
+- [What's working well]
+
+### Gaps
+- [What's missing or weak]
+
+### Recommendations
+**Quick Wins (1-2 days):**
+- [Specific actionable item]
+
+**High-Value Investments (1-4 weeks):**
+- [Specific actionable item]
+```

--- a/plugins/codebase-readiness/skills/codebase-readiness/references/dimensions/code-clarity.md
+++ b/plugins/codebase-readiness/skills/codebase-readiness/references/dimensions/code-clarity.md
@@ -1,0 +1,98 @@
+# Code Clarity
+
+## Why This Matters for Agent Readiness
+
+Code clarity determines whether an agent can understand and modify individual files without excessive context. When files are small, focused, and well-named, an agent can fit a complete unit of logic in its context window, understand its purpose from the filename alone, and make targeted changes with confidence. Large, multi-responsibility files force agents to process irrelevant code, increasing the chance of unintended modifications and reducing the effective scope of autonomous work.
+
+## What to Examine
+
+- **Filesystem as interface**: The file and directory structure is the primary way an agent navigates a codebase. Clear structure means clear intent — the agent should be able to infer what a file does from its path and name before reading it
+- **File size distribution**: What is the distribution of file sizes across the codebase? Are most files small and focused, or are there many large files?
+- **God files / large classes**: Files exceeding 500-1000 lines typically contain multiple responsibilities and are difficult for agents to modify safely
+- **Naming clarity**: Can the purpose of a file/class/module be inferred from its name? Vague names (utils, helpers, misc, common, shared) force agents to read files to understand them
+- **Single Responsibility Principle**: Do files and classes have a single, clear purpose? Or do they mix multiple concerns?
+- **Catch-all directories**: Directories named utils/, helpers/, common/, shared/, misc/ are red flags — they attract unfocused code that has no natural home, making it hard for agents to know what lives where
+
+## Evidence-Gathering Commands
+
+```bash
+# Top 20 largest source files (across common languages)
+find . -name "*.rb" -o -name "*.ts" -o -name "*.tsx" -o -name "*.py" -o -name "*.go" -o -name "*.js" -o -name "*.scala" -o -name "*.java" 2>/dev/null \
+  | grep -v node_modules | grep -v .git | grep -v vendor | grep -v spec | grep -v test \
+  | xargs wc -l 2>/dev/null | sort -rn | head -21
+
+# Average file size
+find . -name "*.rb" -o -name "*.ts" -o -name "*.tsx" -o -name "*.py" -o -name "*.go" -o -name "*.js" -o -name "*.scala" -o -name "*.java" 2>/dev/null \
+  | grep -v node_modules | grep -v .git | grep -v vendor | grep -v spec | grep -v test \
+  | xargs wc -l 2>/dev/null | awk '{sum+=$1; count++} END {if(count>1) print "Average:", sum/(count-1), "lines"}'
+
+# Files over 500 lines
+find . -name "*.rb" -o -name "*.ts" -o -name "*.tsx" -o -name "*.py" -o -name "*.go" -o -name "*.js" -o -name "*.scala" -o -name "*.java" 2>/dev/null \
+  | grep -v node_modules | grep -v .git | grep -v vendor | grep -v spec | grep -v test \
+  | xargs wc -l 2>/dev/null | awk '$1 > 500' | sort -rn | head -10
+
+# Files over 1000 lines (god files)
+find . -name "*.rb" -o -name "*.ts" -o -name "*.tsx" -o -name "*.py" -o -name "*.go" -o -name "*.js" -o -name "*.scala" -o -name "*.java" 2>/dev/null \
+  | grep -v node_modules | grep -v .git | grep -v vendor | grep -v spec | grep -v test \
+  | xargs wc -l 2>/dev/null | awk '$1 > 1000' | sort -rn | head -10
+
+# Directory structure (first 30 directories)
+find . -type d 2>/dev/null | grep -v node_modules | grep -v .git | grep -v vendor | head -30
+
+# Catch-all directories
+find . -type d \( -name "utils" -o -name "helpers" -o -name "common" -o -name "shared" -o -name "misc" -o -name "lib" \) 2>/dev/null \
+  | grep -v node_modules | grep -v .git | grep -v vendor
+
+# Files in catch-all directories (how much code hides there)
+for dir in utils helpers common shared misc; do
+  COUNT=$(find . -type f -path "*/$dir/*" 2>/dev/null | grep -v node_modules | grep -v .git | grep -v vendor | wc -l)
+  if [ "$COUNT" -gt 0 ]; then
+    echo "$dir/: $COUNT files"
+  fi
+done
+```
+
+## Scoring Bands
+
+- **0-20**: Many files exceed 1000 lines. No obvious organizational principle. God files are common. Naming is vague or inconsistent. Agent cannot infer file purpose from path.
+- **21-40**: Files commonly 500-1000 lines. Some organization but mixed concerns within files. Naming partially informative but catch-all directories (utils/, helpers/) contain significant code.
+- **41-60**: Most files 200-500 lines. Reasonable naming conventions. Some god files remain but are outliers. Directory structure provides moderate navigability. Agent can usually infer purpose from path.
+- **61-80**: Typical file under 300 lines. Clear, descriptive naming. Single Responsibility Principle mostly followed with few outliers. Catch-all directories minimal. Agent can confidently navigate and modify individual files.
+- **81-100**: Typical file under 200 lines. Excellent naming that communicates intent. SRP evident throughout. Directory structure reveals domain concepts. No catch-all directories. Agent can understand any file's purpose from its path alone.
+
+NOTE: For dimensions where scoring bands differ materially by language, these bands provide the general framing. The language file provides concrete criteria and tooling-specific thresholds.
+
+## Score Modifiers
+
+- **No files exceed 500 lines**: **+5**
+- **Catch-all directories (utils/, helpers/, etc.) contain >20 files each**: **-5**
+- **More than 10 god files (>1000 lines)**: **-10**
+
+## Output Format
+
+```markdown
+## Code Clarity Assessment
+
+**Score: XX/100**
+
+### Evidence
+- Average file size: [X lines]
+- Files over 500 lines: [count]
+- Files over 1000 lines (god files): [count, largest listed]
+- Catch-all directories: [list with file counts]
+- Directory depth: [typical nesting level]
+- Naming quality: [excellent / good / mixed / poor — examples]
+
+### Strengths
+- [What's working well]
+
+### Gaps
+- [What's missing or weak]
+
+### Recommendations
+**Quick Wins (1-2 days):**
+- [Specific actionable item]
+
+**High-Value Investments (1-4 weeks):**
+- [Specific actionable item]
+```

--- a/plugins/codebase-readiness/skills/codebase-readiness/references/dimensions/consistency.md
+++ b/plugins/codebase-readiness/skills/codebase-readiness/references/dimensions/consistency.md
@@ -1,0 +1,83 @@
+# Consistency & Conventions
+
+## Why This Matters for Agent Readiness
+
+Consistency determines whether an agent can learn patterns from one part of the codebase and apply them reliably elsewhere. When code style, formatting, and architectural patterns are enforced automatically, the agent generates code that fits seamlessly. Without enforcement, the agent must guess which style to follow — and inconsistent style across the codebase means any guess may be wrong. Automated enforcement also acts as a safety net: if the agent produces code that violates conventions, linters and formatters catch it before it reaches review.
+
+## What to Examine
+
+- **Linting configuration**: Is a linter configured? How strict is it? Are rules customized for the project or just defaults?
+- **Formatter configuration**: Is an auto-formatter configured? Is it opinionated (single way to format) or flexible?
+- **Pre-commit hooks enforcing lint/format**: Do local hooks catch violations before code is committed?
+- **CI pipeline enforcement**: Does CI fail when lint or format violations are present? Is this a required check?
+- **Custom/architectural linters**: Beyond style rules, are there linters that enforce architectural decisions and domain rules? These are especially valuable for agents because:
+  - They encode decisions that are hard to infer from code alone
+  - Error messages act as "context injection" — when an agent violates a rule, the error message teaches it the correct approach
+  - Examples: "don't import from domain X in domain Y", "all API handlers must call authorize()", "database queries must go through the repository layer"
+
+## Evidence-Gathering Commands
+
+```bash
+# Pre-commit hooks
+ls .husky/ 2>/dev/null && echo "=== Husky hooks ===" && ls .husky/
+ls .pre-commit-config.yaml 2>/dev/null && echo "=== pre-commit config ===" && head -30 .pre-commit-config.yaml
+ls lefthook.yml 2>/dev/null && echo "=== Lefthook config ===" && head -30 lefthook.yml
+
+# CI enforcement of lint/format
+grep -r "lint\|format\|style\|rubocop\|eslint\|prettier\|black\|ruff\|golangci\|checkstyle\|spotless" \
+  .github/ .circleci/ .buildkite/ 2>/dev/null | grep -v ".git" | head -10
+
+# Lint/format config files (generic — covers most ecosystems)
+find . -maxdepth 2 \( \
+  -name ".eslintrc*" -o -name ".prettierrc*" -o -name ".rubocop.yml" -o \
+  -name "pyproject.toml" -o -name ".flake8" -o -name ".pylintrc" -o \
+  -name ".golangci.yml" -o -name "checkstyle.xml" -o -name ".scalafmt.conf" -o \
+  -name "biome.json" -o -name "deno.json" -o -name ".stylelintrc*" \
+\) 2>/dev/null | grep -v node_modules | grep -v .git
+```
+
+NOTE: Detailed linter/formatter detection, rule counting, and strictness analysis commands are language-specific and belong in language files.
+
+## Scoring Bands
+
+- **0-20**: No linting configuration. No formatter. Code style varies across files with no consistency. Agent has no automated feedback on style violations.
+- **21-40**: Linting configuration exists but is not enforced in CI. No pre-commit hooks. Formatter may be configured but not required. Agent may generate code that passes locally but violates unstated conventions.
+- **41-60**: Linting enforced in CI, OR formatter configured and used — but not both enforced together. Some style consistency achieved but gaps remain. Agent gets partial automated feedback.
+- **61-80**: Both linting and formatting configured. CI enforces at least one. Pre-commit hooks present. Style is largely consistent across the codebase. Agent gets reliable feedback on most style issues.
+- **81-100**: Linting and formatting both enforced in CI (build fails on violations). Auto-format runs on commit via hooks. Custom/architectural linters enforce domain rules beyond style. Agent gets comprehensive, immediate feedback on both style and architectural violations.
+
+NOTE: For dimensions where scoring bands differ materially by language, these bands provide the general framing. The language file provides concrete criteria and tooling-specific thresholds.
+
+## Score Modifiers
+
+- **Custom/architectural linters present** (enforcing domain rules, not just style): **+10**
+- **Auto-format on commit** (via pre-commit hooks): **+3**
+- **Linter configured but >20% of rules disabled/overridden**: **-5**
+
+## Output Format
+
+```markdown
+## Consistency & Conventions Assessment
+
+**Score: XX/100**
+
+### Evidence
+- Linter: [tool name — configured / CI-enforced / absent]
+- Formatter: [tool name — configured / CI-enforced / absent]
+- Pre-commit hooks: [present / absent — what they enforce]
+- CI enforcement: [lint only / format only / both / neither]
+- Custom/architectural linters: [present / absent — description if present]
+
+### Strengths
+- [What's working well]
+
+### Gaps
+- [What's missing or weak]
+
+### Recommendations
+**Quick Wins (1-2 days):**
+- [Specific actionable item]
+
+**High-Value Investments (1-4 weeks):**
+- [Specific actionable item]
+```

--- a/plugins/codebase-readiness/skills/codebase-readiness/references/dimensions/documentation.md
+++ b/plugins/codebase-readiness/skills/codebase-readiness/references/dimensions/documentation.md
@@ -1,0 +1,242 @@
+# Documentation
+
+## Why This Matters for Agent Readiness
+
+Documentation is the primary mechanism through which a codebase communicates intent, constraints, and conventions to an AI agent. Without it, the agent must infer architecture from code alone — a process that is slow, error-prone, and misses critical context like "why" decisions were made. Well-structured documentation allows an agent to understand the codebase quickly, respect existing conventions, and avoid repeating mistakes the team has already learned from.
+
+Critically, documentation quality is not just about **presence** — it's about **coherence**. Duplicated or contradictory instructions across multiple docs cause agents to make unpredictable choices about which guidance to follow. A codebase with a well-written CLAUDE.md that contradicts its own TESTING.md is worse than one with a single, shorter CLAUDE.md that delegates clearly.
+
+## What to Examine
+
+### Four Documentation Artifact Types
+
+| Artifact | Purpose | Agent Value |
+|----------|---------|-------------|
+| **CLAUDE.md** | Direct instructions to the agent — conventions, gotchas, workflow rules | Highest — agent reads this first |
+| **ARCHITECTURE.md** | Structural overview — component map, boundaries, data flow | High — enables navigation without reading all code |
+| **ADRs** | Decision records — why choices were made, what alternatives were rejected | High — prevents agent from re-proposing rejected approaches |
+| **Topic docs** | Focused guides — CONVENTIONS.md, TESTING.md, DEPLOYMENT.md, etc. | Medium — provides domain-specific depth |
+
+### CLAUDE.md Assessment
+
+- **Presence**: Does a root CLAUDE.md exist?
+- **Structure quality**: Is it well-organized with clear sections, or a wall of text?
+- **@imports**: Does it use @-imports to reference other docs rather than duplicating content?
+- **Bloat anti-pattern**: Is it excessively long (>500 lines)? Bloated CLAUDE.md files degrade agent performance — they should be concise and link out to detailed docs
+- **Nested CLAUDE.md files**: Are there domain-specific CLAUDE.md files in subdirectories? This signals mature agent-aware documentation architecture
+- **Actionable content**: Does it contain actual instructions (do this, don't do that) vs. just descriptions?
+- **Role discipline**: Is CLAUDE.md acting as a concise directive index (linking to detailed docs), or has it absorbed tutorial-style content that belongs in topic docs? Signs of role confusion include: code examples longer than 10 lines, "how-to" sections with multiple steps, or reference material (API lists, module inventories)
+
+### ARCHITECTURE.md Assessment
+
+- **Codemap presence**: Does it provide a map of the codebase structure — what lives where and why?
+- **Component inventory**: Are all major components/services/modules listed with their responsibilities?
+- **Invariants**: Are system invariants and constraints documented (e.g., "all API responses must include request_id", "never delete user records — soft delete only")?
+- **API boundaries**: Are the boundaries between components documented — what is public API vs. internal?
+- **Cross-cutting concerns**: Are concerns that span multiple components documented (auth, logging, error handling)?
+
+### ADR Assessment
+
+- **Presence**: Do Architecture Decision Records exist?
+- **Quality signals**: Do ADRs include alternatives considered, rationale for the choice, and consequences/trade-offs?
+- **Recency**: Are ADRs still being written, or did the practice stop?
+- **Discoverability**: Are ADRs in a standard location (docs/adr/, docs/decisions/, etc.)?
+
+### Topic Documentation Assessment
+
+- **CONVENTIONS.md**: Coding conventions beyond what linters enforce
+- **TESTING.md**: Testing philosophy, patterns, how to write tests for this codebase
+- **Other topic docs**: DEPLOYMENT.md, API.md, DATABASE.md, etc.
+
+### README Assessment
+
+- **Setup instructions**: Can a new developer (or agent) get a working environment from the README alone?
+- **Architecture overview**: Does it provide or link to a high-level architecture description?
+- **Contribution guidelines**: Are there clear instructions for how to contribute?
+
+### Documentation Coherence
+
+Documentation quality isn't just about presence — it's about whether docs form a **coherent, non-contradictory system**. Agents that encounter conflicting instructions between CLAUDE.md and topic docs will make unpredictable choices about which to follow. This is one of the most impactful — and most commonly missed — documentation failure modes.
+
+- **Duplication between CLAUDE.md and topic docs**: Does CLAUDE.md inline content that already exists in dedicated docs (e.g., testing patterns duplicated from TESTING.md)? Duplicated content drifts apart over time and creates conflicting instructions. Look for sections in CLAUDE.md that cover topics already addressed by dedicated docs in `docs/`.
+- **Source of truth clarity**: When CLAUDE.md and a topic doc both cover the same topic, is it clear which takes precedence? Does CLAUDE.md delegate via @-import, or does it maintain its own competing version? Look for topic docs that declare themselves "authoritative" while CLAUDE.md contains its own rules on the same topic.
+- **Cross-document consistency**: Do instructions in CLAUDE.md align with what topic docs, README, and ARCHITECTURE.md say? Look for contradictions in:
+  - Recommended patterns (e.g., one doc says "prefer X" while another shows Y as acceptable)
+  - Tool/library preferences (e.g., one doc recommends MSW, another shows jest.mock as valid)
+  - Naming conventions, file organization, or workflow rules
+- **CLAUDE.md role discipline**: Is CLAUDE.md acting as a concise directive index (linking to detailed docs), or has it absorbed tutorial-style content that belongs in topic docs? Measure the ratio of directive lines (containing "must", "never", "always", "avoid", "prefer") to total lines. A healthy CLAUDE.md has a high directive density. Signs of role confusion include:
+  - Code examples longer than 10 lines (tutorials belong in topic docs)
+  - "How-to" sections with multiple implementation steps
+  - Reference material like API inventories or module lists
+  - Sections that exceed 30 lines on a single topic
+
+### Documentation CI Enforcement
+
+- **Link checking**: Are documentation links verified in CI?
+- **Freshness checks**: Are there mechanisms to detect stale documentation?
+
+## Evidence-Gathering Commands
+
+```bash
+# CLAUDE.md presence and structure
+find . -name "CLAUDE.md" 2>/dev/null | grep -v node_modules | grep -v .git
+wc -l CLAUDE.md 2>/dev/null
+grep -c "@" CLAUDE.md 2>/dev/null  # @imports
+
+# ARCHITECTURE.md
+find . -name "ARCHITECTURE.md" -o -name "ARCHITECTURE.rst" 2>/dev/null | grep -v node_modules | grep -v .git
+wc -l ARCHITECTURE.md 2>/dev/null
+
+# ADRs
+find . -type d -name "adr" -o -name "adrs" -o -name "decisions" -o -name "decision-records" 2>/dev/null | grep -v node_modules | grep -v .git
+find . -path "*/adr/*.md" -o -path "*/adrs/*.md" -o -path "*/decisions/*.md" 2>/dev/null | grep -v node_modules | grep -v .git | wc -l
+
+# Topic documentation
+find . -maxdepth 2 -name "CONVENTIONS.md" -o -name "TESTING.md" -o -name "DEPLOYMENT.md" -o -name "API.md" -o -name "DATABASE.md" -o -name "CONTRIBUTING.md" 2>/dev/null | grep -v node_modules | grep -v .git
+
+# Also check docs/ directory for topic docs with different naming
+find docs/ doc/ -maxdepth 1 -name "*.md" 2>/dev/null | grep -v node_modules | grep -v .git | head -20
+
+# README
+ls README.md README.rst README 2>/dev/null
+wc -l README.md 2>/dev/null
+
+# Docs directory
+find docs/ -type f 2>/dev/null | head -20
+find doc/ -type f 2>/dev/null | head -20
+
+# Documentation CI enforcement
+grep -r "markdown\|markdownlint\|link-check\|docs" .github/ .circleci/ .buildkite/ 2>/dev/null | grep -v ".git" | head -5
+```
+
+### Coherence Evidence Commands
+
+```bash
+# CLAUDE.md content type analysis
+echo "=== CLAUDE.md content breakdown ==="
+if [ -f CLAUDE.md ]; then
+  echo "Total lines: $(wc -l < CLAUDE.md)"
+  echo "Code block lines: $(sed -n '/^```/,/^```/p' CLAUDE.md | wc -l)"
+  echo "Sections (## headings): $(grep -c '^##' CLAUDE.md)"
+  echo "Directive keywords (must/never/always/avoid/prefer): $(grep -ci 'must\|never\|always\|avoid\|prefer' CLAUDE.md)"
+  TOTAL=$(wc -l < CLAUDE.md)
+  CODE=$(sed -n '/^```/,/^```/p' CLAUDE.md | wc -l)
+  if [ "$TOTAL" -gt 0 ]; then
+    PCT=$(( CODE * 100 / TOTAL ))
+    echo "Code example percentage: ${PCT}%"
+  fi
+fi
+
+# Topic overlap: does CLAUDE.md cover topics that have dedicated docs?
+echo "=== Topic overlap between CLAUDE.md and dedicated docs ==="
+for doc in $(find docs/ doc/ -name "*.md" -maxdepth 2 2>/dev/null | grep -v node_modules); do
+  TOPIC=$(basename "$doc" .md | tr '[:upper:]' '[:lower:]' | sed 's/_/ /g')
+  if grep -qi "$TOPIC" CLAUDE.md 2>/dev/null; then
+    CLAUDE_LINES=$(grep -ci "$TOPIC" CLAUDE.md 2>/dev/null)
+    DOC_LINES=$(wc -l < "$doc" 2>/dev/null | tr -d ' ')
+    echo "  Overlap: '$TOPIC' — CLAUDE.md mentions ${CLAUDE_LINES}x, dedicated doc is ${DOC_LINES} lines"
+  fi
+done
+
+# Validate @-imports and doc references resolve to real files
+echo "=== Broken documentation references ==="
+if [ -f CLAUDE.md ]; then
+  # Check @-import style references
+  grep -oE '@[a-zA-Z0-9_./-]+\.md' CLAUDE.md 2>/dev/null | while read -r ref; do
+    FILE=$(echo "$ref" | sed 's/^@//')
+    if [ ! -f "$FILE" ]; then
+      echo "  BROKEN @-import: $ref -> $FILE not found"
+    fi
+  done
+  # Check markdown link references
+  grep -oE '\[.*\]\(\./[^)]+\)' CLAUDE.md 2>/dev/null | grep -oE '\./[^)]+' | while read -r ref; do
+    if [ ! -f "$ref" ]; then
+      echo "  BROKEN link: $ref not found"
+    fi
+  done
+fi
+
+# Conflicting patterns: check if CLAUDE.md "avoid" patterns appear as valid examples in topic docs
+echo "=== Potential cross-document conflicts ==="
+if [ -f CLAUDE.md ] && [ -d docs/ ]; then
+  # Extract function/method patterns marked as "avoid" in CLAUDE.md
+  grep -B1 -A3 '❌.*[Aa]void\|# ❌\|\/\/ ❌' CLAUDE.md 2>/dev/null | \
+    grep -oE '[a-zA-Z]+\.[a-zA-Z]+\(|[a-zA-Z]+\(\)' | sort -u | while read -r pattern; do
+    # Check if these "avoid" patterns appear as valid/recommended in topic docs
+    TOPIC_HITS=$(grep -rl "$pattern" docs/ 2>/dev/null | grep -v node_modules)
+    if [ -n "$TOPIC_HITS" ]; then
+      # Verify the pattern isn't also marked as "avoid" in the topic doc
+      for hit in $TOPIC_HITS; do
+        if ! grep -B2 "$pattern" "$hit" 2>/dev/null | grep -qi 'avoid\|❌\|don.t'; then
+          echo "  CONFLICT: CLAUDE.md marks '$pattern' as avoid, but $hit shows it as valid"
+        fi
+      done
+    fi
+  done
+fi
+
+# Source of truth declarations
+echo "=== Source of truth declarations ==="
+grep -rn "source of truth\|authoritative\|canonical\|definitive" CLAUDE.md docs/ 2>/dev/null | grep -v node_modules | grep -v .git
+```
+
+## Scoring Bands
+
+- **0-20**: No CLAUDE.md, no ARCHITECTURE.md, no ADRs. README is minimal or absent. Agent must infer everything from code alone.
+- **21-40**: README exists with basic setup. No CLAUDE.md or ARCHITECTURE.md. No ADRs. Agent has minimal guidance beyond code structure.
+- **41-60**: CLAUDE.md exists but may be unstructured or bloated. Some documentation present (README, partial architecture notes). No ADRs or topic docs. Agent has some guidance but significant gaps. Documentation may contain duplicated or contradictory content across files.
+- **61-80**: CLAUDE.md is well-structured and concise, with no contradictions against topic docs. CLAUDE.md delegates to topic docs via @-imports rather than duplicating content. ARCHITECTURE.md present with codemap. Some ADRs exist. Topic docs cover key areas. Agent can navigate and understand most of the codebase from documentation.
+- **81-100**: CLAUDE.md well-structured with @imports and nested domain files. No duplication or conflicts between CLAUDE.md and topic docs — clear source-of-truth boundaries. ARCHITECTURE.md comprehensive with invariants and boundaries. ADRs actively maintained. Topic docs cover conventions, testing, and deployment. Documentation freshness enforced in CI. Agent has rich, reliable context for any change.
+
+NOTE: For dimensions where scoring bands differ materially by language, these bands provide the general framing. The language file provides concrete criteria and tooling-specific thresholds.
+
+## Score Modifiers
+
+### Positive Modifiers
+- **ADRs present and actively maintained** (written within last 6 months): **+5**
+- **Nested CLAUDE.md files in 3+ directories**: **+5**
+- **Documentation link checking in CI**: **+3**
+- **All @-imports and doc references in CLAUDE.md resolve to existing files**: **+3**
+
+### Negative Modifiers
+- **CLAUDE.md >500 lines without @imports** (bloat anti-pattern): **-10**
+- **Conflicting instructions detected** between CLAUDE.md and topic docs (e.g., CLAUDE.md marks a pattern as "avoid" but a topic doc shows it as valid/recommended): **-10**
+- **CLAUDE.md duplicates content from topic docs** (>20 lines of overlapping content on the same topic without @-import delegation): **-5**
+- **CLAUDE.md code examples exceed 30% of total lines** (tutorial content that belongs in topic docs, not directive content): **-5**
+
+## Output Format
+
+```markdown
+## Documentation Assessment
+
+**Score: XX/100**
+
+### Evidence
+- CLAUDE.md: [present / absent — line count, @imports count, nested files count]
+- CLAUDE.md content profile: [code example %, directive keyword density, section count]
+- ARCHITECTURE.md: [present / absent — line count, key sections found]
+- ADRs: [count, most recent date, location]
+- Topic docs: [list of files found]
+- README: [present / absent — line count, key sections found]
+- Documentation CI: [link checking / freshness checks / none]
+
+### Coherence
+- Topic overlap: [list of topics covered in both CLAUDE.md and dedicated docs]
+- Cross-document conflicts: [count and description of contradictions found]
+- Source of truth clarity: [clear / ambiguous — details if ambiguous]
+- Broken references: [count of broken @-imports or markdown links]
+- CLAUDE.md role: [directive index / mixed / tutorial-heavy]
+
+### Strengths
+- [What's working well]
+
+### Gaps
+- [What's missing or weak]
+
+### Recommendations
+**Quick Wins (1-2 days):**
+- [Specific actionable item]
+
+**High-Value Investments (1-4 weeks):**
+- [Specific actionable item]
+```

--- a/plugins/codebase-readiness/skills/codebase-readiness/references/dimensions/feedback-loops.md
+++ b/plugins/codebase-readiness/skills/codebase-readiness/references/dimensions/feedback-loops.md
@@ -1,0 +1,109 @@
+# Feedback Loops
+
+## Why This Matters for Agent Readiness
+
+Feedback loops determine how quickly an agent can iterate. A 5-minute CI pipeline enables roughly 100 iterations per day; a 45-minute pipeline allows roughly 10. Speed is a structural prerequisite — the faster the feedback, the more the agent can attempt, verify, and correct within a given time window. Beyond speed, the breadth of signals (security scanning, dependency auditing, coverage reporting) determines whether the agent gets comprehensive feedback or only partial verification.
+
+## What to Examine
+
+- **CI/CD presence and platform**: Is there a CI/CD system? Which platform (GitHub Actions, CircleCI, BuildKite, GitLab CI, Jenkins, etc.)?
+- **Pipeline speed**: Estimated wall-clock time from push to green/red signal. This is the fundamental constraint on agent iteration rate
+- **Caching**: Are dependencies and build artifacts cached between runs to avoid redundant work?
+- **Test parallelization**: Are tests split across parallel jobs or shards to reduce wall-clock time?
+- **Fail-fast configuration**: Does the pipeline abort early on first failure rather than running all jobs to completion?
+- **Pre-commit hooks**: Are there local checks (lint, format, type check) that catch issues before they reach CI?
+- **Non-functional verification signals**: Beyond tests, does CI provide:
+  - Security scanning (SAST, dependency vulnerability scanning)
+  - Coverage reporting (absolute thresholds and delta on PRs)
+  - Dependency auditing (Dependabot, Renovate, scheduled audits)
+- **Ephemeral and concurrent dev environments**: Can agents spin up isolated environments that do not interfere with each other or with human developers? Four signals to check:
+  - Containerized/reproducible dev setup (Docker, devcontainer, Nix)
+  - Per-branch or per-PR environments
+  - Independent database/state per environment
+  - No shared mutable state between environments
+
+## Evidence-Gathering Commands
+
+```bash
+# CI config presence
+find .github/workflows .circleci .buildkite .gitlab -name "*.yml" -o -name "*.yaml" 2>/dev/null | head -10
+wc -l .github/workflows/*.yml 2>/dev/null | sort -rn | head -5
+
+# Caching in CI
+grep -r "cache\|Cache" .github/ .circleci/ .buildkite/ 2>/dev/null | grep -v ".git" | head -10
+
+# Parallel execution
+grep -r "parallel\|matrix\|shard\|split" .github/ .circleci/ .buildkite/ 2>/dev/null | grep -v ".git" | head -10
+
+# Fail-fast configuration
+grep -r "fail-fast\|failFast\|fail_fast" .github/ .circleci/ .buildkite/ 2>/dev/null | grep -v ".git" | head -5
+
+# Pre-commit hooks
+ls .husky/ 2>/dev/null && ls .husky/
+ls .pre-commit-config.yaml 2>/dev/null
+ls lefthook.yml 2>/dev/null
+
+# Coverage in CI feedback
+grep -r "codecov\|coveralls\|coverage-report\|lcov\|coverage" .github/ .circleci/ .buildkite/ 2>/dev/null | grep -v ".git" | head -5
+
+# Dependency vulnerability scanning
+ls .github/dependabot.yml 2>/dev/null && echo "Dependabot configured"
+ls renovate.json .renovaterc 2>/dev/null && echo "Renovate configured"
+
+# Security scanning in CI
+grep -r "security\|sast\|codeql\|snyk\|trivy\|semgrep\|brakeman\|bandit\|gosec" .github/ .circleci/ .buildkite/ 2>/dev/null | grep -v ".git" | head -5
+
+# Ephemeral environment signals
+ls docker-compose*.yml Dockerfile .devcontainer/ 2>/dev/null
+grep -r "review-app\|preview\|ephemeral\|per-branch" .github/ .circleci/ .buildkite/ 2>/dev/null | grep -v ".git" | head -5
+```
+
+## Scoring Bands
+
+- **0-20**: No CI/CD pipeline. Agent changes cannot be verified automatically. No feedback mechanism beyond manual testing.
+- **21-40**: Basic CI exists and runs tests, but no caching or parallelization. Estimated pipeline time exceeds 15 minutes. No pre-commit hooks. Feedback is slow and limited to pass/fail.
+- **41-60**: CI with caching configured. Estimated pipeline under 15 minutes. Some additional signals beyond tests (coverage or linting). Agent gets reasonably fast feedback but misses optimization opportunities.
+- **61-80**: Caching, parallel job execution, and pre-commit hooks all present. Estimated pipeline under 10 minutes. Multiple verification signals (tests, coverage, linting). Agent iterates efficiently with good feedback breadth.
+- **81-100**: Estimated sub-5-minute CI. Parallel execution, pre-commit hooks, fail-fast configuration, security scanning, coverage reporting on PRs. Agent gets fast, comprehensive feedback on every change.
+
+NOTE: For dimensions where scoring bands differ materially by language, these bands provide the general framing. The language file provides concrete criteria and tooling-specific thresholds.
+
+## Score Modifiers
+
+- **Ephemeral + concurrent dev environments** (all 4 signals present): **+8**; partial (1-2 signals): **+3**
+- **Security scanner in CI**: **+5**
+- **Dependabot, Renovate, or scheduled dependency audit**: **+3**
+- **Coverage delta reported on PRs**: **+2**
+
+## Output Format
+
+```markdown
+## Feedback Loops Assessment
+
+**Score: XX/100**
+
+### Evidence
+- CI platform: [platform name]
+- Estimated pipeline time: [X minutes — basis for estimate]
+- Caching: [yes / no — what is cached]
+- Parallelization: [yes / no — details]
+- Fail-fast: [yes / no]
+- Pre-commit hooks: [present / absent — tool and checks]
+- Coverage reporting: [in CI / on PRs / absent]
+- Security scanning: [present / absent — tools]
+- Dependency scanning: [present / absent — tool]
+- Ephemeral environments: [full / partial / absent — signals found]
+
+### Strengths
+- [What's working well]
+
+### Gaps
+- [What's missing or weak]
+
+### Recommendations
+**Quick Wins (1-2 days):**
+- [Specific actionable item]
+
+**High-Value Investments (1-4 weeks):**
+- [Specific actionable item]
+```

--- a/plugins/codebase-readiness/skills/codebase-readiness/references/dimensions/test-foundation.md
+++ b/plugins/codebase-readiness/skills/codebase-readiness/references/dimensions/test-foundation.md
@@ -1,0 +1,97 @@
+# Test Foundation
+
+## Why This Matters for Agent Readiness
+
+Tests are the primary verification mechanism an agent uses to confirm its changes are correct. Without a reliable test foundation, an agent operates blind — it can generate code but cannot verify it works. The quality of the test foundation directly determines the scope of changes an agent can safely make autonomously. A codebase with 100% meaningful coverage represents a phase change: the agent can modify any file and get immediate, reliable feedback on correctness.
+
+## What to Examine
+
+- **Test-to-source file ratio**: The primary structural metric. What percentage of source files have corresponding test files?
+- **Coverage configuration**: Is a coverage tool configured? What thresholds are set?
+- **CI enforcement**: Does CI fail when coverage drops below thresholds?
+- **Test pyramid indicators**: Is there a healthy distribution across unit tests, integration tests, and end-to-end tests? Or is coverage concentrated in one layer?
+- **Oracle quality**: How reliable is the verification signal the tests provide?
+  - **Flaky test evidence**: Git history with "flaky", "intermittent", "skip test" commits signals unreliable oracles
+  - **Mock/stub density**: When mocks greatly outnumber real interactions, tests may pass while real behavior fails
+  - **Property-based testing**: Tests with adversarial/randomized inputs catch edge cases agents might introduce
+  - **Integration test presence**: Unit tests alone miss interaction bugs — integration tests verify components work together
+- **Mutation testing presence**: Does the codebase use mutation testing to verify test quality, not just coverage quantity?
+
+## Evidence-Gathering Commands
+
+```bash
+# Test file counts (underscore convention — e.g., user_test.go, user_spec.rb)
+find . -name "*_test*" -o -name "*_spec*" -o -name "test_*" 2>/dev/null \
+  | grep -v node_modules | grep -v .git | grep -v target | grep -v vendor | wc -l
+
+# Test file counts (dot convention — e.g., user.test.ts, user.spec.js)
+find . -name "*.test.*" -o -name "*.spec.*" 2>/dev/null \
+  | grep -v node_modules | grep -v .git | grep -v target | wc -l
+
+# Source file count (for ratio calculation — adjust extensions per language)
+find . -name "*.rb" -o -name "*.ts" -o -name "*.tsx" -o -name "*.py" -o -name "*.go" -o -name "*.js" -o -name "*.scala" -o -name "*.java" 2>/dev/null \
+  | grep -v node_modules | grep -v .git | grep -v target | grep -v vendor | grep -v spec | grep -v test | grep -v __tests__ | wc -l
+
+# Test organization — how tests are structured
+find . -type d \( -name "spec" -o -name "test" -o -name "tests" -o -name "__tests__" -o -name "e2e" -o -name "integration" -o -name "unit" \) 2>/dev/null \
+  | grep -v node_modules | grep -v .git | grep -v target | head -10
+
+# Flaky test indicators in git history
+git log --oneline 2>/dev/null | grep -i "flak\|intermit\|flakey\|skip test\|disable test" | wc -l
+
+# Coverage configuration presence
+find . -name ".coveragerc" -o -name "coverage.config*" -o -name ".nycrc*" -o -name "jest.config*" -o -name "codecov.yml" -o -name ".simplecov" 2>/dev/null \
+  | grep -v node_modules | grep -v .git | head -5
+
+# CI coverage enforcement
+grep -r "coverage\|--cov\|simplecov\|codecov\|coveralls" .github/ .circleci/ .buildkite/ 2>/dev/null | grep -v .git | head -10
+```
+
+## Scoring Bands
+
+- **0-20**: No tests or less than 5% test-to-source ratio. Agent has no verification mechanism for its changes.
+- **21-40**: Tests exist but less than 20% ratio. No coverage configuration. No CI enforcement. Tests provide spotty verification at best.
+- **41-60**: 20-40% test-to-source ratio. Coverage configuration present. Some CI integration. Agent can verify changes in well-tested areas but must be cautious elsewhere.
+- **61-80**: 40-60% ratio. Coverage thresholds enforced in CI. Test pyramid visible (unit + integration layers). Agent can verify most changes with reasonable confidence.
+- **81-100**: Greater than 60% ratio. Coverage enforced in CI with meaningful thresholds. Test pyramid healthy. Mutation testing or property-based tests present. Agent can verify changes comprehensively.
+
+NOTE: For dimensions where scoring bands differ materially by language, these bands provide the general framing. The language file provides concrete criteria and tooling-specific thresholds.
+
+## Score Modifiers
+
+- **Property-based testing present and actively used**: **+5**
+- **Test retry/flaky-test plugins present** (signals systemic flakiness): **-10**
+- **Skipped/disabled tests exceed 5% of total**: **-5**
+- **Mock/stub count exceeds 3x test file count**: **-5**
+- **All tests are unit tests with no integration layer**: **-10**
+
+## Output Format
+
+```markdown
+## Test Foundation Assessment
+
+**Score: XX/100**
+
+### Evidence
+- Test-to-source file ratio: [X test files / Y source files = Z%]
+- Coverage configuration: [present / absent — tool and thresholds if present]
+- CI coverage enforcement: [yes / no — details]
+- Test pyramid: [unit only / unit + integration / unit + integration + e2e]
+- Flaky test signals: [count of git commits mentioning flakiness]
+- Mock/stub density: [low / moderate / high]
+- Property-based testing: [present / absent]
+- Mutation testing: [present / absent]
+
+### Strengths
+- [What's working well]
+
+### Gaps
+- [What's missing or weak]
+
+### Recommendations
+**Quick Wins (1-2 days):**
+- [Specific actionable item]
+
+**High-Value Investments (1-4 weeks):**
+- [Specific actionable item]
+```

--- a/plugins/codebase-readiness/skills/codebase-readiness/references/dimensions/type-safety.md
+++ b/plugins/codebase-readiness/skills/codebase-readiness/references/dimensions/type-safety.md
@@ -1,0 +1,70 @@
+# Type Safety
+
+## Why This Matters for Agent Readiness
+
+Type safety determines what mechanisms prevent agent mistakes from silently passing through the system and reaching production. When an agent generates incorrect code, type enforcement acts as the first automated safety net — catching mismatched parameters, invalid data shapes, and contract violations before they reach runtime. The stronger the type safety infrastructure, the more confidently an agent can make changes knowing that errors will surface early.
+
+## What to Examine
+
+- **Language type tier**: Is the language statically-typed, dynamically-typed, or gradually-typed? This determines *how* safety is expressed, not *whether* it exists
+- **Type enforcement mechanisms**: Whatever form safety takes in this language — are they present, configured, and enforced?
+- **CI enforcement**: Do type checks run as a required gate in CI?
+- **Semantic type names**: Does the codebase use domain-specific types (e.g., `UserId` vs bare `string`, `EmailAddress` vs `str`) that communicate intent and constrain valid values?
+- **Database-level invariants**: Do database constraints (CHECK, NOT NULL, UNIQUE, REFERENCES, triggers, custom types/domains) extend type enforcement beyond application code?
+- **API contract types**: Are API boundaries typed via OpenAPI specs or generated clients, ensuring external integrations are type-safe?
+- **Strictness level**: Is the type system configured at its strictest practical level, or are escape hatches (any types, type:ignore, unsafe casts) widespread?
+
+## Evidence-Gathering Commands
+
+```bash
+# Database constraints (works for any language with migrations)
+grep -r "check\|constraint\|NOT NULL\|UNIQUE\|REFERENCES\|trigger" db/migrate/ migrations/ 2>/dev/null | grep -v node_modules | grep -v .git | wc -l
+grep -r "CREATE TRIGGER\|CREATE TYPE\|CREATE DOMAIN" db/ 2>/dev/null | head -5
+
+# OpenAPI / generated typed clients
+find . -name "openapi*" -o -name "swagger*" 2>/dev/null | grep -v node_modules | grep -v .git | head -5
+```
+
+NOTE: Type checker detection, configuration analysis, and escape-hatch counting commands are language-specific and live in language files.
+
+## Scoring Bands
+
+- **0-20**: No type safety mechanisms in place. No type checker, no contract enforcement, no runtime validation. Agent mistakes pass silently.
+- **21-40**: Minimal type safety. Some mechanisms exist but are not enforced in CI, have low coverage, or are configured at a permissive level. Escape hatches are common.
+- **41-60**: Moderate type safety. Type enforcement is configured and partially enforced. CI may run checks but they are not strict or not required. Some domain types exist but usage is inconsistent.
+- **61-80**: Strong type safety. Type enforcement is active and CI-enforced. Strict configuration with few escape hatches. Semantic domain types are used in key areas. Most code paths are covered.
+- **81-100**: Comprehensive type safety. Strictest configuration enforced in CI with near-zero escape hatches. Semantic types used pervasively. Domain boundaries are type-enforced.
+
+NOTE: For dimensions where scoring bands differ materially by language, these bands provide the general framing. The language file provides concrete criteria and tooling-specific thresholds.
+
+## Score Modifiers
+
+- **Database-level invariants present** (CHECK constraints, triggers, custom types/domains actively used): **+5**
+- **OpenAPI with generated typed clients**: **+5**
+
+## Output Format
+
+```markdown
+## Type Safety Assessment
+
+**Score: XX/100**
+
+### Evidence
+- Language: [detected]
+- Language tier: [statically-typed / dynamically-typed / gradually-typed]
+- [Language-specific evidence items — agent will fill based on language file]
+- CI enforcement: [yes/no — details]
+
+### Strengths
+- [What's working well]
+
+### Gaps
+- [What's missing or weak]
+
+### Recommendations
+**Quick Wins (1-2 days):**
+- [Specific actionable item]
+
+**High-Value Investments (1-4 weeks):**
+- [Specific actionable item]
+```

--- a/plugins/codebase-readiness/skills/codebase-readiness/references/languages/go.md
+++ b/plugins/codebase-readiness/skills/codebase-readiness/references/languages/go.md
@@ -1,0 +1,162 @@
+# Go — Language-Specific Assessment Criteria
+
+> **Note:** This is a thinner reference file with room for expansion as more Go-specific patterns are identified in practice.
+
+## Language Classification
+- **Tier:** statically-typed
+- **Primary safety mechanism:** Compile-time type checking with explicit error handling via return values
+- **Key principle:** Go's type system and explicit error returns are the primary safety mechanisms; assess quality of type usage, interface design, and error handling discipline.
+
+## Type Safety
+### What to Examine
+- Use of `interface{}` / `any` (Go 1.18+) — lower frequency is better
+- Custom types for domain concepts (type UserId int64, type Email string)
+- Interface compliance and design: small, focused interfaces
+- Error handling: custom error types, error wrapping (fmt.Errorf with %w), sentinel errors
+- Struct tags for validation
+
+### Evidence Commands
+```bash
+echo "=== interface{}/any usage ==="
+grep -r "interface{}\|any" --include="*.go" . 2>/dev/null | grep -v vendor | grep -v .git | wc -l
+
+echo "=== Custom types ==="
+grep -r "^type " --include="*.go" . 2>/dev/null | grep -v vendor | grep -v .git | wc -l
+
+echo "=== Interface definitions ==="
+grep -r "type.*interface {" --include="*.go" . 2>/dev/null | grep -v vendor | grep -v .git | wc -l
+
+echo "=== Error wrapping ==="
+grep -r "fmt.Errorf.*%w\|errors.Is\|errors.As" --include="*.go" . 2>/dev/null | grep -v vendor | grep -v .git | wc -l
+
+echo "=== Validation libraries ==="
+grep -r "validator\|validate" go.mod 2>/dev/null | head -5
+
+echo "=== Struct tags ==="
+grep -r "validate:\"" --include="*.go" . 2>/dev/null | grep -v vendor | grep -v .git | wc -l
+```
+
+### Scoring Criteria
+- **0-20**: Loose typing, widespread interface{}/any, no custom types, bare error returns
+- **21-40**: Basic structs but no custom types for domain concepts, minimal error wrapping
+- **41-60**: Custom types present, some interface contracts, basic error wrapping
+- **61-80**: Well-defined interfaces, custom error types, struct validation tags, consistent error wrapping
+- **81-100**: Comprehensive type system usage, validation libraries, minimal interface{}/any, sentinel errors with wrapping
+
+### Language-Specific Notes
+- Go's type system is intentionally simple; quality is measured by how well it is leveraged, not by advanced type features.
+- `interface{}` / `any` is Go's escape hatch — treat it like `any` in TypeScript.
+- Error handling discipline (wrapping, custom types, consistent patterns) is a key Go quality signal.
+
+## Test Foundation
+### Tooling & Detection
+- **Framework:** go test (built-in, standard)
+- **Coverage:** go test -coverprofile (built-in)
+- **Mutation testing:** Limited ecosystem; gremlins, go-mutesting
+- **Property-based testing:** gopter, rapid
+- **File convention:** *_test.go files in the same package
+
+### Evidence Commands
+```bash
+echo "=== Test file count ==="
+find . -name "*_test.go" 2>/dev/null | grep -v vendor | grep -v .git | wc -l
+
+echo "=== Source file count ==="
+find . -name "*.go" -not -name "*_test.go" 2>/dev/null | grep -v vendor | grep -v .git | wc -l
+
+echo "=== Coverage in CI ==="
+grep -r "coverprofile\|coverage\|go test" .github/ .circleci/ .buildkite/ Makefile 2>/dev/null | head -5
+
+echo "=== Table-driven tests (Go idiom) ==="
+grep -r "tests := \[\]struct\|tt := \[\]struct\|testCases" --include="*_test.go" . 2>/dev/null | grep -v vendor | grep -v .git | wc -l
+
+echo "=== Property-based testing ==="
+grep -r "gopter\|rapid" go.mod 2>/dev/null | head -3
+
+echo "=== Skipped tests ==="
+grep -r "t.Skip\|testing.Short" --include="*_test.go" . 2>/dev/null | grep -v vendor | grep -v .git | wc -l
+```
+
+### Scoring Notes
+- **Skip patterns:** `t.Skip()`, `testing.Short()`
+- **Mock indicators:** Generated mocks (mockgen), testify mocks, interface-based test doubles
+- Table-driven tests are idiomatic Go and a positive signal
+- Go's built-in test tooling means no framework setup overhead; lack of tests is a stronger negative signal
+
+## Feedback Loops
+### Tooling
+- **Pre-commit:** lefthook, pre-commit framework
+- **Parallel test runner:** go test runs packages in parallel by default; `-parallel` flag for test-level parallelism
+- **Security scanners:** gosec, govulncheck
+
+### Evidence Commands
+```bash
+ls lefthook.yml .pre-commit-config.yaml 2>/dev/null
+grep -r "gosec\|govulncheck\|staticcheck" .github/ .circleci/ .buildkite/ Makefile 2>/dev/null | head -5
+```
+
+## Code Clarity
+### Conventions
+- **Extensions:** .go
+- **Idiomatic file size:** Shorter files preferred; one type per file is idiomatic Go
+- **Naming:** camelCase for unexported, PascalCase for exported; short variable names idiomatic in small scopes
+- **File organization:** Package-based; package name matches directory name
+
+## Consistency & Conventions
+### Tooling
+- **Linter:** golangci-lint (.golangci.yml or .golangci.yaml) — aggregates many linters
+- **Formatter:** gofmt (built-in, universally adopted); goimports for import organization
+- **Static analysis:** staticcheck, vet (built-in)
+
+### Evidence Commands
+```bash
+echo "=== golangci-lint config ==="
+ls .golangci.yml .golangci.yaml 2>/dev/null
+
+echo "=== CI linting ==="
+grep -r "golangci\|golint\|staticcheck\|go vet" .github/ .circleci/ .buildkite/ Makefile 2>/dev/null | head -5
+
+echo "=== Makefile targets ==="
+grep -r "lint\|fmt\|vet" Makefile 2>/dev/null | head -5
+```
+
+## Architecture
+### Framework Conventions
+- **Go module layout:** cmd/ (entrypoints), internal/ (private packages), pkg/ (public packages)
+- **Dependency injection:** wire, fx, or manual constructor injection
+- **API frameworks:** net/http (stdlib), gin, echo, chi
+
+### Evidence Commands
+```bash
+echo "=== Standard layout ==="
+ls cmd/ internal/ pkg/ 2>/dev/null
+
+echo "=== Module structure ==="
+find . -name "go.mod" 2>/dev/null | grep -v vendor | grep -v .git | head -5
+
+echo "=== Directory structure ==="
+find . -maxdepth 2 -type d 2>/dev/null | grep -v vendor | grep -v .git | head -20
+
+echo "=== DI framework ==="
+grep -r "wire\|uber.org/fx\|dig" go.mod 2>/dev/null | head -5
+```
+
+### Co-Change Notes
+- go.sum churn is expected on dependency updates and should not penalize
+- cmd/ + internal/ co-changes for the same feature are expected
+
+## Change Safety
+### Tooling
+- **Feature flags:** Custom implementations, go-feature-flag, LaunchDarkly Go SDK
+- **Database migrations:** golang-migrate, goose, atlas
+- **Dependency management:** Go modules (go.mod)
+
+### Evidence Commands
+```bash
+echo "=== Feature flags ==="
+grep -r "feature.flag\|feature_flag\|featureflag\|launchdarkly" --include="*.go" . 2>/dev/null | grep -v vendor | grep -v .git | grep -v _test.go | wc -l
+
+echo "=== Migration tools ==="
+grep -r "golang-migrate\|goose\|atlas" go.mod 2>/dev/null | head -5
+find . -path "*/migrations/*" -name "*.sql" 2>/dev/null | grep -v vendor | wc -l
+```

--- a/plugins/codebase-readiness/skills/codebase-readiness/references/languages/java.md
+++ b/plugins/codebase-readiness/skills/codebase-readiness/references/languages/java.md
@@ -1,0 +1,181 @@
+# Java — Language-Specific Assessment Criteria
+
+> **Note:** This is a thinner reference file with room for expansion as more Java-specific patterns are identified in practice.
+
+## Language Classification
+- **Tier:** statically-typed
+- **Primary safety mechanism:** Compile-time type checking with strong generics, annotation-based validation, and null safety annotations
+- **Key principle:** Java's type system is robust by default; assess quality of generics usage, validation framework adoption, and null safety discipline.
+
+## Type Safety
+### What to Examine
+- Generics usage quality: raw types vs parameterized types
+- Annotation-based validation: Bean Validation (javax.validation / jakarta.validation), Hibernate Validator
+- Null safety: Optional usage for nullable returns, @Nullable/@NonNull annotations
+- Raw Object casts as escape hatch — lower frequency is better
+- Record types (Java 14+) and sealed classes (Java 17+) for domain modeling
+
+### Evidence Commands
+```bash
+echo "=== Validation framework ==="
+grep -r "javax.validation\|jakarta.validation\|hibernate-validator" pom.xml build.gradle 2>/dev/null | head -5
+
+echo "=== Optional usage ==="
+grep -r "Optional<" --include="*.java" . 2>/dev/null | grep -v .git | grep -v target | grep -v build | wc -l
+
+echo "=== Null safety annotations ==="
+grep -r "@Nullable\|@NonNull\|@NotNull\|@Nonnull" --include="*.java" . 2>/dev/null | grep -v .git | grep -v target | wc -l
+
+echo "=== Raw type usage (bad signal) ==="
+grep -r "List \|Map \|Set \|Collection " --include="*.java" . 2>/dev/null | grep -v .git | grep -v target | grep -v "import " | wc -l
+
+echo "=== Record types (modern Java) ==="
+grep -r "public record\|record " --include="*.java" . 2>/dev/null | grep -v .git | grep -v target | wc -l
+
+echo "=== Validation annotations ==="
+grep -r "@Valid\|@NotNull\|@NotBlank\|@Size\|@Pattern\|@Min\|@Max" --include="*.java" . 2>/dev/null | grep -v .git | grep -v target | wc -l
+```
+
+### Scoring Criteria
+- **0-20**: Raw types, no generics, widespread Object casts, no validation framework
+- **21-40**: Basic generics but no validation annotations, raw types still present
+- **41-60**: Generics + some validation annotations, Optional partially adopted
+- **61-80**: Comprehensive generics, Bean Validation across domain, Optional for nullable returns
+- **81-100**: Full type safety, validation framework, null safety annotations throughout, minimal raw types, modern Java features (records, sealed classes)
+
+### Language-Specific Notes
+- Java's type system is strong out of the box; the key differentiator is how well it is leveraged.
+- Raw types (List instead of List<String>) are the primary escape hatch — treat like `any` in TypeScript.
+- Optional should be used for return types, not parameters (this is the Java convention).
+
+## Test Foundation
+### Tooling & Detection
+- **Framework:** JUnit 5 (preferred), JUnit 4, TestNG
+- **Coverage:** JaCoCo
+- **Mutation testing:** PIT (pitest) — well-established in Java ecosystem
+- **Property-based testing:** jqwik, junit-quickcheck
+- **File convention:** *Test.java, *Spec.java in src/test/
+
+### Evidence Commands
+```bash
+echo "=== Test file count ==="
+find . -name "*Test.java" -o -name "*Spec.java" 2>/dev/null | grep -v .git | grep -v target | grep -v build | wc -l
+
+echo "=== Source file count ==="
+find . -name "*.java" -not -name "*Test.java" -not -name "*Spec.java" 2>/dev/null | grep -v .git | grep -v target | grep -v build | wc -l
+
+echo "=== JaCoCo coverage ==="
+grep -r "jacoco\|JaCoCo" pom.xml build.gradle 2>/dev/null | head -5
+
+echo "=== Mutation testing (PIT) ==="
+grep -r "pitest\|PIT\|pit-maven" pom.xml build.gradle 2>/dev/null | head -5
+
+echo "=== Property-based testing ==="
+grep -r "jqwik\|junit-quickcheck" pom.xml build.gradle 2>/dev/null | head -5
+
+echo "=== Skipped tests ==="
+grep -r "@Disabled\|@Ignore" --include="*.java" . 2>/dev/null | grep -v .git | grep -v target | wc -l
+
+echo "=== Mock density ==="
+grep -r "@Mock\|Mockito\|mock(\|when(\|verify(" --include="*.java" . 2>/dev/null | grep -v .git | grep -v target | wc -l
+
+echo "=== CI coverage ==="
+grep -r "jacoco\|coverage\|surefire\|failsafe" .github/ .circleci/ .buildkite/ 2>/dev/null | head -5
+```
+
+### Scoring Notes
+- **Skip patterns:** `@Disabled` (JUnit 5), `@Ignore` (JUnit 4)
+- **Mock indicators:** `@Mock`, `Mockito`, `mock()`, `when()`, `verify()`
+- PIT mutation testing is well-supported in Java and its presence is a strong positive signal
+- JUnit 5 adoption over JUnit 4 indicates a modern, maintained test suite
+
+## Feedback Loops
+### Tooling
+- **Pre-commit:** Limited pre-commit culture in Java; Spotless plugin for formatting on build
+- **Parallel test runner:** Maven Surefire parallel mode, Gradle parallel test execution
+- **Security scanners:** SpotBugs (security rules), OWASP Dependency Check, Snyk
+
+### Evidence Commands
+```bash
+echo "=== Spotless (format enforcement) ==="
+grep -r "spotless" pom.xml build.gradle 2>/dev/null | head -5
+
+echo "=== Security scanning ==="
+grep -r "spotbugs\|owasp\|dependency-check\|snyk" pom.xml build.gradle .github/ .circleci/ .buildkite/ 2>/dev/null | head -5
+
+echo "=== Parallel test execution ==="
+grep -r "parallel\|forkCount\|useUnlimitedThreads" pom.xml build.gradle 2>/dev/null | head -5
+```
+
+## Code Clarity
+### Conventions
+- **Extensions:** .java
+- **Idiomatic file size:** One public class per file (enforced by the language)
+- **Naming:** PascalCase for classes, camelCase for methods/variables, UPPER_SNAKE_CASE for constants
+- **File organization:** Package hierarchy mirrors directory structure; src/main/java and src/test/java split
+
+## Consistency & Conventions
+### Tooling
+- **Linter:** Checkstyle, SpotBugs, PMD
+- **Formatter:** google-java-format, Eclipse formatter, Spotless plugin
+- **Build tool:** Maven (pom.xml), Gradle (build.gradle / build.gradle.kts)
+
+### Evidence Commands
+```bash
+echo "=== Linter config ==="
+grep -r "checkstyle\|spotbugs\|pmd" pom.xml build.gradle 2>/dev/null | head -5
+ls checkstyle.xml 2>/dev/null
+
+echo "=== Formatter ==="
+grep -r "google-java-format\|spotless\|formatter" pom.xml build.gradle 2>/dev/null | head -5
+
+echo "=== CI linting ==="
+grep -r "checkstyle\|spotbugs\|pmd\|lint" .github/ .circleci/ .buildkite/ 2>/dev/null | head -5
+
+echo "=== Build tool ==="
+ls pom.xml build.gradle build.gradle.kts 2>/dev/null
+```
+
+## Architecture
+### Framework Conventions
+- **Spring Boot:** src/main/java with controller/service/repository layering
+- **Maven modules:** Multi-module project for domain boundaries (pom.xml in subdirectories)
+- **Gradle multi-project:** settings.gradle with include statements for subprojects
+- **General:** src/main/java, src/main/resources, src/test/java layout
+
+### Evidence Commands
+```bash
+echo "=== Spring structure ==="
+find . -name "*Controller.java" -o -name "*Service.java" -o -name "*Repository.java" 2>/dev/null | grep -v .git | grep -v target | head -10
+
+echo "=== Maven modules ==="
+find . -name "pom.xml" -not -path "*/target/*" 2>/dev/null | head -10
+
+echo "=== Gradle subprojects ==="
+grep -r "include " settings.gradle settings.gradle.kts 2>/dev/null | head -10
+
+echo "=== Directory structure ==="
+find . -maxdepth 3 -type d -path "*/src/main/java/*" 2>/dev/null | head -15
+```
+
+### Co-Change Notes
+- Spring controller + service + repository co-changes for the same feature are expected
+- Maven/Gradle build file churn on dependency updates is expected
+- application.properties / application.yml frequent changes are expected in active projects
+
+## Change Safety
+### Tooling
+- **Feature flags:** Togglz, FF4J, LaunchDarkly Java SDK, Unleash
+- **Database migrations:** Flyway, Liquibase
+- **Dependency management:** Maven (pom.xml), Gradle (build.gradle)
+
+### Evidence Commands
+```bash
+echo "=== Feature flags ==="
+grep -r "togglz\|ff4j\|launchdarkly\|unleash\|feature.flag" pom.xml build.gradle 2>/dev/null | head -5
+grep -r "isActive\|isEnabled\|featureFlag\|FeatureToggle" --include="*.java" . 2>/dev/null | grep -v .git | grep -v target | grep -v test | wc -l
+
+echo "=== Database migrations ==="
+grep -r "flyway\|liquibase" pom.xml build.gradle 2>/dev/null | head -5
+find . -path "*/db/migration/*" -o -path "*/changelog/*" 2>/dev/null | grep -v .git | grep -v target | wc -l
+```

--- a/plugins/codebase-readiness/skills/codebase-readiness/references/languages/javascript.md
+++ b/plugins/codebase-readiness/skills/codebase-readiness/references/languages/javascript.md
@@ -1,0 +1,165 @@
+# JavaScript — Language-Specific Assessment Criteria
+
+## Language Classification
+- **Tier:** dynamically-typed
+- **Primary safety mechanism:** Runtime validation libraries (Zod, Joi, yup) and JSDoc annotations for editor-level type checking
+- **Key principle:** Plain JavaScript projects lack compile-time type safety; assess runtime validation coverage and recommend TypeScript migration as a high-value investment for any plain JS project.
+
+> **Standing recommendation:** For ANY plain JavaScript project, recommend TypeScript migration in High-Value Investments. The @ts-check JSDoc approach is a zero-migration-cost first step.
+
+## Type Safety
+### What to Examine
+- JSDoc annotations as partial type safety signal (`@param`, `@returns`, `@type`)
+- Runtime validation libraries: Zod, Joi, yup at API boundaries and data ingestion points
+- TypeScript migration status: presence of any .ts files, allowJs in tsconfig, @ts-check comments
+- PropTypes usage in React projects (legacy but still a signal)
+
+### Evidence Commands
+```bash
+echo "=== Project type ==="
+ls tsconfig.json 2>/dev/null && echo "TypeScript project (or mixed)" || echo "JavaScript project (no tsconfig.json)"
+
+echo "=== File counts ==="
+find . -name "*.ts" -o -name "*.tsx" 2>/dev/null | grep -v node_modules | grep -v .git | wc -l
+find . -name "*.js" -o -name "*.jsx" 2>/dev/null | grep -v node_modules | grep -v .git | wc -l
+
+echo "=== Runtime validation ==="
+grep -r "\"zod\"\|\"joi\"\|\"yup\"\|\"ajv\"" package.json 2>/dev/null
+
+echo "=== JSDoc usage ==="
+grep -r "@param\|@returns\|@type\|@typedef" --include="*.js" --include="*.jsx" . 2>/dev/null | grep -v node_modules | grep -v .git | wc -l
+
+echo "=== @ts-check usage ==="
+grep -r "@ts-check" --include="*.js" --include="*.jsx" . 2>/dev/null | grep -v node_modules | grep -v .git | wc -l
+
+echo "=== PropTypes (React) ==="
+grep -r "PropTypes\|prop-types" --include="*.js" --include="*.jsx" . 2>/dev/null | grep -v node_modules | grep -v .git | wc -l
+```
+
+### Scoring Criteria
+- **0-20**: Plain JS, no JSDoc annotations, no runtime validation
+- **21-40**: Plain JS with some JSDoc, no runtime validation
+- **41-60**: Runtime validation library (Zod/Joi/yup) in use, JSDoc on critical interfaces
+- **61-80**: Comprehensive runtime validation, JSDoc annotations, TypeScript migration started (some .ts files or allowJs in tsconfig)
+- **81-100**: TypeScript migration complete or substantially underway with strict mode
+
+### Language-Specific Notes
+- Any plain JavaScript project should receive a TypeScript migration recommendation regardless of score.
+- `@ts-check` at the top of JS files enables TypeScript checking with zero migration cost — recommend this as a first step.
+- JSDoc + `@ts-check` can provide near-TypeScript safety without renaming files.
+
+## Test Foundation
+### Tooling & Detection
+- **Framework:** Jest (jest.config.*), Vitest (vitest.config.*), Mocha (.mocharc.*)
+- **Coverage:** jest --coverage, c8, istanbul/nyc
+- **Mutation testing:** Stryker (@stryker-mutator/*)
+- **Property-based testing:** fast-check
+
+### Evidence Commands
+```bash
+echo "=== Test framework ==="
+ls jest.config.* vitest.config.* .mocharc.* 2>/dev/null
+grep -r "\"jest\"\|\"vitest\"\|\"mocha\"" package.json 2>/dev/null | head -5
+
+echo "=== Coverage config ==="
+grep -r "coverageThreshold\|collectCoverage" jest.config.* vitest.config.* 2>/dev/null | head -5
+grep -r "nyc\|istanbul\|c8" package.json 2>/dev/null | head -5
+
+echo "=== Mutation testing ==="
+grep -r "stryker" package.json 2>/dev/null
+
+echo "=== Property-based testing ==="
+grep -r "fast-check" package.json 2>/dev/null
+
+echo "=== Skipped tests ==="
+grep -r "\.skip\|xit\|xdescribe\|xtest" --include="*.test.*" --include="*.spec.*" . 2>/dev/null | grep -v node_modules | grep -v .git | wc -l
+
+echo "=== Mock density ==="
+grep -r "jest.fn\|jest.mock\|vi.fn\|vi.mock\|sinon" --include="*.test.*" --include="*.spec.*" . 2>/dev/null | grep -v node_modules | grep -v .git | wc -l
+```
+
+### Scoring Notes
+- **Skip patterns:** `.skip`, `xit`, `xdescribe`, `xtest`
+- **Mock indicators:** `jest.fn`, `jest.mock`, `vi.fn`, `vi.mock`, `sinon`
+- Without static types, test coverage becomes even more critical in JS projects — weight test foundation higher.
+
+## Feedback Loops
+### Tooling
+- **Pre-commit:** Husky (.husky/ directory), lint-staged
+- **Parallel test runner:** Jest workers (default), Vitest threads
+- **Security scanners:** npm audit, CodeQL, Snyk
+
+### Evidence Commands
+```bash
+echo "=== Pre-commit ==="
+ls .husky/ 2>/dev/null
+grep -r "husky\|lint-staged" package.json 2>/dev/null | head -5
+
+echo "=== Security ==="
+grep -r "npm audit\|snyk\|codeql" .github/ .circleci/ .buildkite/ 2>/dev/null | head -5
+```
+
+## Code Clarity
+### Conventions
+- **Extensions:** .js, .jsx (React components)
+- **Idiomatic file size:** Similar to TypeScript; components should be focused
+- **Naming:** camelCase for files/variables, PascalCase for components/classes
+- **File organization:** Co-location patterns common in React; module-based organization in Node.js
+
+## Consistency & Conventions
+### Tooling
+- **Linter:** ESLint (.eslintrc.*, eslint.config.*)
+- **Formatter:** Prettier (.prettierrc*, .prettierignore)
+- **Custom rules:** Custom ESLint rules or plugins for project-specific patterns
+
+### Evidence Commands
+```bash
+echo "=== ESLint config ==="
+ls .eslintrc.* eslint.config.* 2>/dev/null
+grep -r "eslint" .github/ .circleci/ .buildkite/ 2>/dev/null | head -5
+
+echo "=== Prettier config ==="
+ls .prettierrc* .prettierignore 2>/dev/null
+
+echo "=== Custom ESLint plugins ==="
+grep -r "eslint-plugin\|eslint-rule" package.json 2>/dev/null | head -5
+```
+
+## Architecture
+### Framework Conventions
+- **Next.js:** pages/ or app/ directory, API routes, components/
+- **Express:** routes/, controllers/, middleware/
+- **Monorepo:** packages/, apps/, libs/ (Turborepo, Nx, Lerna)
+- **General:** src/ directory as source root
+
+### Evidence Commands
+```bash
+echo "=== Framework detection ==="
+grep -r "\"next\"\|\"express\"\|\"fastify\"\|\"koa\"" package.json 2>/dev/null | head -5
+
+echo "=== Monorepo structure ==="
+find . -maxdepth 3 -name "package.json" 2>/dev/null | grep -v node_modules | grep -v .git | wc -l
+ls packages/ apps/ libs/ modules/ 2>/dev/null
+
+echo "=== Directory structure ==="
+find . -maxdepth 2 -type d 2>/dev/null | grep -v node_modules | grep -v .git | head -20
+```
+
+### Co-Change Notes
+- package-lock.json / yarn.lock churn is expected and should not penalize
+- In monorepos, shared package changes triggering consumer updates is expected
+
+## Change Safety
+### Tooling
+- **Feature flags:** LaunchDarkly, Unleash, custom feature-flags packages, environment-based flags
+- **Database migrations:** Knex migrations, Sequelize migrations, Prisma migrations
+
+### Evidence Commands
+```bash
+echo "=== Feature flags ==="
+grep -r "launchdarkly\|unleash\|feature-flag\|featureFlag" package.json 2>/dev/null | head -5
+grep -r "featureFlag\|feature_flag\|isEnabled\|isFeatureEnabled" --include="*.js" --include="*.jsx" . 2>/dev/null | grep -v node_modules | grep -v .git | grep -v test | wc -l
+
+echo "=== Database migrations ==="
+find . -path "*/migrations/*" -name "*.js" 2>/dev/null | grep -v node_modules | grep -v .git | wc -l
+```

--- a/plugins/codebase-readiness/skills/codebase-readiness/references/languages/python.md
+++ b/plugins/codebase-readiness/skills/codebase-readiness/references/languages/python.md
@@ -1,0 +1,170 @@
+# Python — Language-Specific Assessment Criteria
+
+## Language Classification
+- **Tier:** gradually-typed
+- **Primary safety mechanism:** Optional type annotations enforced via mypy/pyright, plus runtime validation via Pydantic
+- **Key principle:** Python supports a spectrum from untyped to fully annotated; assess where the codebase falls on that spectrum and whether enforcement exists in CI.
+
+## Type Safety
+### What to Examine
+- Type annotation density in source files (function signatures, variable annotations)
+- mypy or pyright configuration and CI enforcement
+- Pydantic usage for runtime validation of inputs and data models
+- py.typed marker file (indicates library exports type information)
+- Use of typing module constructs: Optional, Union, List, Dict, TypeVar, Protocol
+
+### Evidence Commands
+```bash
+echo "=== Type annotation density (sample) ==="
+find . -name "*.py" 2>/dev/null | grep -v node_modules | grep -v .git | grep -v test | grep -v __pycache__ | head -5 \
+  | xargs grep -l "def.*->.*:\|: str\|: int\|: Optional\|: List" 2>/dev/null | wc -l
+
+echo "=== mypy / pyright config ==="
+ls mypy.ini .mypy.ini pyproject.toml 2>/dev/null
+grep "\[tool.mypy\]\|\[mypy\]" pyproject.toml mypy.ini .mypy.ini 2>/dev/null | head -5
+grep -r "pyright\|pyrightconfig" . 2>/dev/null | grep -v node_modules | grep -v .git | head -5
+
+echo "=== Pydantic usage ==="
+grep -r "pydantic" requirements*.txt pyproject.toml setup.py setup.cfg 2>/dev/null | head -3
+
+echo "=== py.typed marker ==="
+find . -name "py.typed" 2>/dev/null | grep -v node_modules | grep -v .git | head -3
+
+echo "=== CI enforcement ==="
+grep -r "mypy\|pyright" .github/ .circleci/ .buildkite/ 2>/dev/null | head -5
+```
+
+### Scoring Criteria
+- **0-20**: No type annotations, no mypy/pyright config
+- **21-40**: <20% of functions annotated, mypy not enforced in CI
+- **41-60**: 20-50% of functions annotated, mypy in CI but not blocking
+- **61-80**: >50% annotated, mypy enforced in CI, Pydantic for critical inputs
+- **81-100**: >80% annotated, mypy strict mode in CI, comprehensive Pydantic models, py.typed marker
+
+### Language-Specific Notes
+- Python's gradual typing means you should look at trajectory — is the codebase moving toward more annotations?
+- Pydantic is the dominant runtime validation pattern in modern Python; its presence is a strong signal.
+- mypy strict mode (`--strict` flag or `strict = true` in config) is a significantly higher bar than default mypy.
+
+## Test Foundation
+### Tooling & Detection
+- **Framework:** pytest (pytest.ini, pyproject.toml [tool.pytest], conftest.py)
+- **Coverage:** pytest-cov, coverage.py ([tool.coverage] in pyproject.toml)
+- **Mutation testing:** mutmut, cosmic-ray
+- **Property-based testing:** Hypothesis
+
+### Evidence Commands
+```bash
+echo "=== Test framework ==="
+ls pytest.ini conftest.py 2>/dev/null
+grep "\[tool.pytest\]" pyproject.toml 2>/dev/null
+
+echo "=== Coverage config ==="
+grep -r "pytest-cov\|coverage" requirements*.txt pyproject.toml setup.py 2>/dev/null | head -5
+grep "\[tool.coverage\]" pyproject.toml 2>/dev/null
+
+echo "=== Mutation testing ==="
+grep -r "mutmut\|cosmic-ray" requirements*.txt pyproject.toml 2>/dev/null | head -3
+
+echo "=== Property-based testing ==="
+grep -r "hypothesis" requirements*.txt pyproject.toml 2>/dev/null | head -3
+
+echo "=== Skipped tests ==="
+grep -r "pytest.mark.skip\|@pytest.mark.skipif\|@unittest.skip" --include="*.py" . 2>/dev/null | grep -v .git | grep -v __pycache__ | wc -l
+
+echo "=== Mock density ==="
+grep -r "mock.patch\|MagicMock\|unittest.mock\|@patch" --include="*.py" . 2>/dev/null | grep -v .git | grep -v __pycache__ | wc -l
+
+echo "=== Test retry ==="
+grep -r "pytest-rerunfailures\|flaky" requirements*.txt pyproject.toml 2>/dev/null | head -3
+```
+
+### Scoring Notes
+- **Skip patterns:** `pytest.mark.skip`, `@pytest.mark.skipif`, `@unittest.skip`
+- **Mock indicators:** `unittest.mock`, `mock.patch`, `MagicMock`, `@patch`
+- **Retry plugins:** pytest-rerunfailures, flaky — presence may indicate flaky test tolerance
+- Hypothesis (property-based testing) is a strong positive signal in Python codebases
+
+## Feedback Loops
+### Tooling
+- **Pre-commit:** .pre-commit-config.yaml (pre-commit framework)
+- **Parallel test runner:** pytest-xdist (`-n auto` flag)
+- **Security scanners:** Bandit (static security analysis), Safety (dependency vulnerabilities)
+
+### Evidence Commands
+```bash
+ls .pre-commit-config.yaml 2>/dev/null
+grep -r "pytest-xdist\|xdist" requirements*.txt pyproject.toml 2>/dev/null | head -3
+grep -r "bandit\|safety" .github/ .circleci/ .buildkite/ requirements*.txt pyproject.toml 2>/dev/null | head -5
+```
+
+## Code Clarity
+### Conventions
+- **Extensions:** .py
+- **Idiomatic file size:** Python modules should be focused; large files (>300 lines) warrant review
+- **Naming:** snake_case for files, functions, variables; CamelCase for classes
+- **File organization:** One module per concern; `__init__.py` files define package boundaries
+
+## Consistency & Conventions
+### Tooling
+- **Linter:** Flake8, Ruff (modern, fast replacement)
+- **Formatter:** Black (opinionated), isort (import sorting)
+- **Configuration:** pyproject.toml sections: [tool.ruff], [tool.flake8], [tool.black], [tool.isort]
+
+### Evidence Commands
+```bash
+echo "=== Linter config ==="
+grep -r "\[tool.ruff\]\|\[tool.flake8\]" pyproject.toml 2>/dev/null | head -5
+ls .flake8 setup.cfg 2>/dev/null
+grep -r "ruff\|flake8" .github/ .circleci/ .buildkite/ 2>/dev/null | head -5
+
+echo "=== Formatter config ==="
+grep -r "\[tool.black\]\|\[tool.isort\]" pyproject.toml 2>/dev/null | head -5
+grep -r "black\|isort" .github/ .circleci/ .buildkite/ 2>/dev/null | head -5
+ls .isort.cfg 2>/dev/null
+```
+
+## Architecture
+### Framework Conventions
+- **Django:** apps/ structure, urls.py, views.py, models.py, admin.py per app
+- **Flask:** blueprints for modular organization
+- **FastAPI:** routers, dependency injection
+- **General Python:** src/ layout, packages with `__init__.py`
+
+### Evidence Commands
+```bash
+echo "=== Django structure ==="
+find . -name "urls.py" -o -name "views.py" -o -name "admin.py" 2>/dev/null | grep -v .git | grep -v __pycache__ | head -10
+
+echo "=== Flask blueprints ==="
+grep -r "Blueprint" --include="*.py" . 2>/dev/null | grep -v .git | grep -v __pycache__ | head -5
+
+echo "=== Package structure ==="
+find . -name "__init__.py" -not -path "*/node_modules/*" -not -path "*/.git/*" -not -path "*/__pycache__/*" 2>/dev/null | head -15
+
+echo "=== Source layout ==="
+ls src/ 2>/dev/null && find src/ -type d 2>/dev/null | head -15
+```
+
+### Co-Change Notes
+- Django model + migration co-changes are expected (same as Rails)
+- Django urls.py + views.py co-changes are expected
+- settings.py high churn is expected in active Django projects
+
+## Change Safety
+### Tooling
+- **Feature flags:** Custom implementations, django-waffle, flagsmith
+- **Migrations:** Django migrations (app/migrations/), Alembic (for SQLAlchemy)
+
+### Evidence Commands
+```bash
+echo "=== Feature flags ==="
+grep -r "waffle\|flagsmith\|feature_flag\|feature_toggle" --include="*.py" . 2>/dev/null | grep -v test | grep -v .git | wc -l
+
+echo "=== Django migrations ==="
+find . -path "*/migrations/*.py" -not -name "__init__.py" 2>/dev/null | grep -v .git | wc -l
+
+echo "=== Alembic ==="
+ls alembic.ini 2>/dev/null
+find . -name "alembic" -type d 2>/dev/null | head -3
+```

--- a/plugins/codebase-readiness/skills/codebase-readiness/references/languages/ruby.md
+++ b/plugins/codebase-readiness/skills/codebase-readiness/references/languages/ruby.md
@@ -1,0 +1,149 @@
+# Ruby — Language-Specific Assessment Criteria
+
+## Language Classification
+- **Tier:** dynamically-typed
+- **Primary safety mechanism:** Test coverage combined with contract libraries (dry-rb ecosystem)
+- **Key principle:** High test coverage plus strong contracts provides safety equivalent to static typing; do NOT penalize for absence of Sorbet.
+
+## Type Safety
+### What to Examine
+- Contract libraries: dry-types, dry-validation, dry-struct, dry-container
+- ActiveRecord validation coverage on domain models
+- Service object interface clarity: consistent `def call` signatures, typed return values via App::Result or similar pattern
+- Sorbet/RBS adoption (bonus only — not required for high scores)
+
+### Evidence Commands
+```bash
+echo "=== ActiveRecord Validations ==="
+find app/models -name "*.rb" 2>/dev/null | xargs grep -l "validates\|validate " 2>/dev/null | wc -l
+
+echo "=== dry-rb adoption ==="
+grep -i "dry-types\|dry-validation\|dry-container\|dry-struct\|dry-rb" Gemfile 2>/dev/null
+
+echo "=== Service object interface patterns ==="
+find app/services -name "*.rb" 2>/dev/null | xargs grep -l "def call\|def self.call" 2>/dev/null | wc -l
+grep -r "App::Result\|Result.success\|Result.failure\|ServiceResult" app/ 2>/dev/null | grep -v spec | wc -l
+
+echo "=== Sorbet / RBS (advanced, bonus) ==="
+ls sorbet/ 2>/dev/null && echo "Sorbet present"
+grep -i "sorbet\|rbs\|steep" Gemfile 2>/dev/null
+```
+
+### Scoring Criteria
+- **0-20**: No validations on domain models, no contract patterns, service interfaces inconsistent
+- **21-40**: Basic ActiveRecord validations only, no contract libraries, service interfaces informal
+- **41-60**: ActiveRecord validations + one dry-rb library OR consistent Result pattern
+- **61-80**: dry-rb contracts across domain layer, consistent service interfaces with explicit success/failure
+- **81-100**: Comprehensive contract system (dry-rb), consistent interfaces, Result pattern, Sorbet as bonus
+
+### Language-Specific Notes
+- Ruby's primary safety mechanism is test coverage. High tests + strong contracts = equivalent to TypeScript strict.
+- DO NOT penalize for lack of Sorbet/RBS. These are bonus indicators, not requirements.
+- Look for consistent patterns across the codebase rather than individual file adoption.
+
+## Test Foundation
+### Tooling & Detection
+- **Framework:** RSpec (spec/ directory, *_spec.rb files)
+- **Coverage:** SimpleCov (.simplecov file)
+- **Mutation testing:** Mutant gem
+- **Property-based testing:** Rantly, Faker (for data generation)
+
+### Evidence Commands
+```bash
+echo "=== Coverage config ==="
+ls .simplecov 2>/dev/null
+grep -r "simplecov" .github/ .circleci/ .buildkite/ 2>/dev/null | head -5
+
+echo "=== Mutation testing ==="
+grep -i "mutant" Gemfile 2>/dev/null
+
+echo "=== Skipped tests ==="
+grep -r "skip\|xit\|xdescribe" --include="*_spec.rb" . 2>/dev/null | grep -v node_modules | grep -v .git | wc -l
+grep -r "pending\b" --include="*_spec.rb" . 2>/dev/null | grep -v node_modules | wc -l
+
+echo "=== Mock/stub density ==="
+grep -r "allow\|stub\|double\|instance_double\|class_double" --include="*_spec.rb" . 2>/dev/null | grep -v node_modules | grep -v .git | wc -l
+
+echo "=== Property-based testing ==="
+grep -i "rantly\|hypothesis\|faker" Gemfile 2>/dev/null | head -5
+
+echo "=== Test retry plugins ==="
+grep -i "rspec-retry" Gemfile 2>/dev/null
+```
+
+### Scoring Notes
+- **Skip patterns:** `skip`, `xit`, `xdescribe`, `pending`
+- **Mock indicators:** `allow`, `stub`, `double`, `instance_double`, `class_double`
+- **Retry plugin:** rspec-retry — presence may indicate flaky test tolerance
+- High mock density relative to test count can indicate shallow testing
+
+## Feedback Loops
+### Tooling
+- **Pre-commit:** lefthook (lefthook.yml)
+- **Parallel test runner:** parallel_tests gem
+- **Security scanners:** Brakeman (static analysis), bundle-audit (dependency vulnerabilities)
+
+### Evidence Commands
+```bash
+ls lefthook.yml 2>/dev/null
+grep -i "parallel_tests" Gemfile 2>/dev/null
+grep -r "brakeman\|bundle-audit" .github/ .circleci/ .buildkite/ Gemfile 2>/dev/null | head -5
+```
+
+## Code Clarity
+### Conventions
+- **Extensions:** .rb
+- **Idiomatic file size:** Ruby files tend to be shorter than JS/TS equivalents; large files (>200 lines) are a stronger smell in Ruby than in some other languages
+- **Naming:** snake_case for files and methods, CamelCase for classes/modules
+- **File organization:** One class per file is conventional, matching the class name to the filename
+
+## Consistency & Conventions
+### Tooling
+- **Linter:** RuboCop (.rubocop.yml or .rubocop.yaml)
+- **Formatter:** RuboCop (doubles as linter and formatter)
+- **Custom rules:** Custom RuboCop cops for project-specific conventions
+
+### Evidence Commands
+```bash
+ls .rubocop.yml .rubocop.yaml 2>/dev/null
+grep -r "rubocop" .github/ .circleci/ .buildkite/ 2>/dev/null | head -5
+find . -name "*.rb" -path "*cop*" -o -name "*.rb" -path "*rubocop*" 2>/dev/null | grep -v vendor | grep -v spec | head -5
+```
+
+## Architecture
+### Framework Conventions
+- **Rails MVC:** app/models, app/controllers, app/services, app/views
+- **Rails engines as domain boundaries:** Strong signal of intentional modular architecture
+- **Gemspec files in subdirectories:** Indicates extracted libraries or engine-based structure
+
+### Evidence Commands
+```bash
+ls app/ 2>/dev/null && ls app/
+find app/ -type d 2>/dev/null | head -20
+find . -name "*.gemspec" -not -path "*/vendor/*" 2>/dev/null | head -10
+find . -path "*/engines/*/lib" -type d 2>/dev/null | head -10
+find . \( -name "*controller*" -o -name "*_controller.rb" \) 2>/dev/null | grep -v node_modules | grep -v .git | grep -v spec | xargs wc -l 2>/dev/null | sort -rn | head -10
+```
+
+### Co-Change Notes
+- **Expected Rails co-changes (NOT bad coupling):**
+  - Model + migration
+  - Controller + view
+  - Model + spec
+- **High churn files to exclude from coupling analysis:**
+  - schema.rb — regenerated on every migration
+  - routes.rb — modified for most feature additions
+  - Locale files (config/locales/) — updated for most user-facing changes
+- These expected co-changes should NOT penalize the architecture score.
+
+## Change Safety
+### Tooling
+- **Feature flags:** Flipper gem
+- **Migrations:** db/migrate/ directory (Rails migrations)
+- **Validation in migrations:** Check for uniqueness constraints, presence validations, and index additions
+
+### Evidence Commands
+```bash
+grep -r "flipper\|feature_flag\|rollout" --include="*.rb" . 2>/dev/null | grep -v spec | grep -v test | wc -l
+grep -r "validates.*uniqueness\|validates.*presence\|add_index.*unique" db/migrate/ 2>/dev/null | wc -l
+```

--- a/plugins/codebase-readiness/skills/codebase-readiness/references/languages/scala.md
+++ b/plugins/codebase-readiness/skills/codebase-readiness/references/languages/scala.md
@@ -1,0 +1,297 @@
+# Scala — Language-Specific Assessment Criteria
+
+## Language Classification
+- **Tier:** statically-typed
+- **Primary safety mechanism:** Compile-time type checking with rich type system (sealed traits, case classes, path-dependent types, implicits) and functional programming patterns (Option, Either, IO monads)
+- **Key principle:** Scala's type system is one of the most expressive in mainstream languages. Assess how well the codebase leverages it — sealed ADTs, Option over null, explicit error types, and domain modeling through types rather than runtime checks.
+
+## Type Safety
+### What to Examine
+- Sealed traits and case classes for algebraic data types (ADTs)
+- Option usage vs null — Scala strongly prefers Option; null presence is a code smell
+- Either/Try for explicit error handling vs thrown exceptions
+- Effect types (cats IO, ZIO, custom monads like EitherT) for typed error channels
+- asInstanceOf as the primary escape hatch — lower frequency is better
+- Any/AnyRef usage — Scala's equivalent of Java's Object
+- Value classes (extends AnyVal) or opaque types for domain newtypes (e.g., UserId wrapping Long)
+- Enumeratum or sealed trait enums vs Scala Enumeration (which loses exhaustivity checking)
+- Protobuf/generated types for domain models at service boundaries
+- Database constraints in schema migrations
+
+### Evidence Commands
+```bash
+echo "=== Sealed traits/classes (ADTs) ==="
+grep -r "sealed trait\|sealed abstract\|sealed class" --include="*.scala" . 2>/dev/null \
+  | grep -v .git | grep -v target | grep -v test | wc -l
+
+echo "=== Case classes ==="
+grep -r "case class" --include="*.scala" . 2>/dev/null \
+  | grep -v .git | grep -v target | grep -v test | wc -l
+
+echo "=== Option usage ==="
+grep -r "Option\[" --include="*.scala" . 2>/dev/null \
+  | grep -v .git | grep -v target | grep -v test | wc -l
+
+echo "=== Null usage (bad signal) ==="
+grep -r "= null\b\|== null\b\|!= null\b\|eq null\b\|ne null\b" --include="*.scala" . 2>/dev/null \
+  | grep -v .git | grep -v target | grep -v test | wc -l
+
+echo "=== asInstanceOf (primary escape hatch) ==="
+grep -r "asInstanceOf\[" --include="*.scala" . 2>/dev/null \
+  | grep -v .git | grep -v target | grep -v test | wc -l
+
+echo "=== Any/AnyRef usage ==="
+grep -r ": Any\b\|: AnyRef\b\|\[Any\]\|\[AnyRef\]" --include="*.scala" . 2>/dev/null \
+  | grep -v .git | grep -v target | grep -v test | wc -l
+
+echo "=== Either usage (explicit error handling) ==="
+grep -r "Either\[" --include="*.scala" . 2>/dev/null \
+  | grep -v .git | grep -v target | grep -v test | wc -l
+
+echo "=== Effect types (cats/ZIO) ==="
+grep -rl "import cats\.\|import zio\.\|EitherT\[" --include="*.scala" . 2>/dev/null \
+  | grep -v .git | grep -v target | grep -v test | wc -l
+
+echo "=== Value classes / newtypes ==="
+grep -r "extends AnyVal\|opaque type" --include="*.scala" . 2>/dev/null \
+  | grep -v .git | grep -v target | grep -v test | wc -l
+
+echo "=== Enumeratum (type-safe enums) ==="
+grep -r "extends EnumEntry\|extends Enum\[" --include="*.scala" . 2>/dev/null \
+  | grep -v .git | grep -v target | grep -v test | wc -l
+
+echo "=== Scala Enumeration (weaker, no exhaustivity) ==="
+grep -r "extends Enumeration" --include="*.scala" . 2>/dev/null \
+  | grep -v .git | grep -v target | grep -v test | wc -l
+
+echo "=== Protobuf-generated types ==="
+find . -name "*.proto" -not -path "*/target/*" 2>/dev/null | wc -l
+
+echo "=== Database constraints ==="
+grep -r "CHECK\|CONSTRAINT\|NOT NULL\|REFERENCES\|FOREIGN KEY\|UNIQUE" --include="*.sql" . 2>/dev/null \
+  | grep -v .git | grep -v target | wc -l
+```
+
+### Scoring Criteria
+- **0-20**: Pervasive null usage, widespread asInstanceOf/Any, no sealed traits, no domain modeling through types
+- **21-40**: Basic case classes but heavy null/Any usage, minimal sealed traits, thrown exceptions as primary error handling
+- **41-60**: Option preferred over null, some sealed traits, Either present but inconsistent, some asInstanceOf casts remain
+- **61-80**: Option pervasive (null near-zero), sealed traits for ADTs, Either/effect types for error handling, few asInstanceOf casts, Enumeratum or sealed enums
+- **81-100**: Comprehensive type-driven design — sealed ADTs, value classes/newtypes for domain IDs, effect system (cats/ZIO) for typed errors, minimal escape hatches, protobuf-generated boundary types
+
+### Language-Specific Notes
+- Scala's primary escape hatches are `asInstanceOf` and `Any` — treat them like `any` in TypeScript.
+- Null is technically legal but culturally unacceptable in idiomatic Scala. A high Option-to-null ratio is a strong positive signal.
+- Scala `Enumeration` loses pattern match exhaustivity — Enumeratum or sealed traits are preferred. Do not penalize codebases migrating from Enumeration if sealed traits/Enumeratum are also present.
+- Effect types (cats IO, ZIO, custom `EitherT[Future, E, A]` monads) provide typed error channels that are invisible to grep-based analysis. Check for `import cats.` or `import zio.` to detect adoption, and count files using the project's effect type (often named `AppIO`, `AugustIO`, etc.).
+- Protobuf-generated case classes provide compile-time safety at service boundaries — count `.proto` files as a type safety signal.
+
+## Test Foundation
+### Tooling & Detection
+- **Framework:** ScalaTest (most common), Specs2, MUnit, uTest
+- **Coverage:** scoverage (sbt-scoverage plugin)
+- **Mutation testing:** Stryker4s
+- **Property-based testing:** ScalaCheck (often via scalatestplus-scalacheck), Hedgehog
+- **File convention:** *Spec.scala, *Test.scala, *Suite.scala in test/ or src/test/scala/
+
+### Evidence Commands
+```bash
+echo "=== Test file count ==="
+find . -name "*Spec.scala" -o -name "*Test.scala" -o -name "*Suite.scala" 2>/dev/null \
+  | grep -v .git | grep -v target | wc -l
+
+echo "=== Source file count ==="
+find . -name "*.scala" -not -path "*/test/*" -not -path "*/it/*" -not -path "*/integration/*" 2>/dev/null \
+  | grep -v .git | grep -v target | grep -v node_modules | wc -l
+
+echo "=== Test framework detection ==="
+grep -r "scalatest\|specs2\|munit\|utest\|scalatestplus" build.sbt project/*.sbt project/*.scala 2>/dev/null | head -10
+
+echo "=== Coverage tool (scoverage) ==="
+grep -r "scoverage\|sbt-scoverage" build.sbt project/*.sbt project/plugins.sbt 2>/dev/null | head -5
+
+echo "=== Mutation testing (Stryker4s) ==="
+grep -r "stryker\|sbt-stryker" build.sbt project/*.sbt project/plugins.sbt 2>/dev/null | head -5
+
+echo "=== Property-based testing (ScalaCheck) ==="
+grep -r "scalacheck\|scalatestplus.*scalacheck\|hedgehog" build.sbt project/*.sbt 2>/dev/null | head -5
+
+echo "=== ScalaCheck active usage (files using forAll) ==="
+find . -name "*.scala" -path "*/test/*" -not -path "*/target/*" -exec grep -l "forAll" {} \; 2>/dev/null | wc -l
+
+echo "=== Skipped/pending tests ==="
+find . -name "*Spec.scala" -o -name "*Test.scala" 2>/dev/null \
+  | grep -v target | xargs grep -c "pending$\|pending " 2>/dev/null \
+  | awk -F: '$2 > 0 {sum += $2} END {print sum+0 " pending tests across files"}'
+grep -rn "ignore(" --include="*Spec.scala" --include="*Test.scala" . 2>/dev/null \
+  | grep -v target | grep -v "import " | wc -l
+
+echo "=== Mock infrastructure (mock files, not usage) ==="
+find . -name "*Mock*.scala" -o -name "*Stub*.scala" -o -name "*Fake*.scala" 2>/dev/null \
+  | grep -v target | grep -v .git | wc -l
+
+echo "=== Mock library usage (Mockito) ==="
+grep -rl "import org.mockito\|import org.scalatestplus.mockito\|MockitoSugar" --include="*.scala" . 2>/dev/null \
+  | grep -v target | grep -v .git | wc -l
+
+echo "=== Integration test presence ==="
+find . -type d \( -name "integration" -o -name "it" \) -not -path "*/target/*" 2>/dev/null | head -5
+find . -name "*.scala" -path "*/integration/*" -o -name "*.scala" -path "*/it/*" 2>/dev/null \
+  | grep -v target | wc -l
+
+echo "=== CI coverage enforcement ==="
+grep -r "scoverage\|coverage" .github/ .circleci/ .buildkite/ 2>/dev/null | head -5
+
+echo "=== Test retry/flaky tolerance ==="
+grep -r "retryable\|eventually\|retry\|flaky" build.sbt project/*.sbt 2>/dev/null | head -5
+```
+
+### Scoring Notes
+- **Skip patterns:** `pending` (ScalaTest — a bare word at end of test body), `ignore("test name")` (ScalaTest method). Do NOT count `ignore` appearing in string literals, imports, or comments.
+- **Mock indicators:** Count mock *files* (Mock*.scala, Stub*.scala, Fake*.scala) and files importing Mockito as separate signals. Do NOT count `when(` or `mock(` via grep — these produce massive false positives in Scala due to pattern matching syntax and common method names.
+- **Property-based testing:** ScalaCheck's `forAll` is the key indicator. Count files containing `forAll` in test directories, not raw grep hits across the codebase.
+- ScalaTest's `eventually` is used for async assertions and can indicate either proper async testing or flaky test tolerance — check context before penalizing.
+- Integration tests in Scala projects often live in a separate `integration/` or `it/` source root with their own sbt configuration (IntegrationTest scope). These test against real databases and external services, providing high oracle quality.
+
+## Feedback Loops
+### Tooling
+- **Pre-commit:** Limited pre-commit culture in Scala; scalafmt can check on build via `scalafmtCheckAll`
+- **Parallel test runner:** sbt parallel execution (default), forked JVMs for isolation
+- **Security scanners:** OWASP Dependency Check (sbt plugin), Snyk, Trivy
+- **Dependency management:** Scala Steward, Renovate, Dependabot
+
+### Evidence Commands
+```bash
+echo "=== Scalafmt in CI ==="
+grep -r "scalafmt\|scalafmtCheck" .github/ .circleci/ .buildkite/ 2>/dev/null | head -5
+
+echo "=== Scalafix in CI ==="
+grep -r "scalafix" .github/ .circleci/ .buildkite/ 2>/dev/null | head -5
+
+echo "=== Fatal warnings ==="
+grep -r "Xfatal-warnings\|fatalWarnings" build.sbt .github/ 2>/dev/null | head -5
+
+echo "=== Security scanning ==="
+grep -r "owasp\|dependency-check\|snyk\|trivy" build.sbt .github/ .circleci/ .buildkite/ 2>/dev/null | head -5
+
+echo "=== Dependency management ==="
+grep -r "scala-steward\|renovate\|dependabot" .github/ 2>/dev/null | head -5
+
+echo "=== Parallel/forked test execution ==="
+grep -r "fork\|parallelExecution\|Test / fork\|IntegrationTest / fork" build.sbt 2>/dev/null | head -5
+
+echo "=== Preflight scripts ==="
+find . -name "preflight" -o -name "pre-flight" -o -name "check" 2>/dev/null \
+  | grep -v target | grep -v .git | grep -v node_modules | head -5
+```
+
+## Code Clarity
+### Conventions
+- **Extensions:** .scala, .sc (Ammonite scripts)
+- **Idiomatic file size:** One class/trait/object per file is conventional, though companion objects colocate with their class. Scala files tend to be concise due to type inference and expression-oriented syntax.
+- **Naming:** PascalCase for classes/traits/objects, camelCase for methods/values/variables, UPPER_SNAKE_CASE for constants
+- **File organization:** Package hierarchy mirrors directory structure. `src/main/scala/` and `src/test/scala/` is the standard Maven/sbt layout. Play Framework uses `app/` instead of `src/main/scala/`.
+- **Auto-generated files:** Slick's `Tables.scala`, protobuf-generated sources in `target/` — exclude these from file size analysis.
+
+## Consistency & Conventions
+### Tooling
+- **Formatter:** scalafmt (.scalafmt.conf) — the standard Scala formatter
+- **Linter:** Scalafix (.scalafix.conf) — semantic linting with custom rule support
+- **Compiler warnings:** `-Xfatal-warnings` treats warnings as errors, acting as an additional linting layer
+- **Custom rules:** Scalafix supports project-specific custom rules — these are a strong positive signal for agent readiness because violations produce error messages that teach the agent the correct pattern
+
+### Evidence Commands
+```bash
+echo "=== Scalafmt config ==="
+find . -name ".scalafmt.conf" -not -path "*/target/*" 2>/dev/null | head -3
+cat .scalafmt.conf 2>/dev/null | head -20
+
+echo "=== Scalafix config ==="
+find . -name ".scalafix.conf" -not -path "*/target/*" 2>/dev/null | head -3
+cat .scalafix.conf 2>/dev/null
+
+echo "=== Custom Scalafix rules ==="
+find . -name "*.scala" -path "*/scalafix/rules/*" -not -path "*/target/*" 2>/dev/null
+find . -name "*.scala" -path "*/scalafix/*" -not -path "*/target/*" 2>/dev/null | head -10
+
+echo "=== CI formatting enforcement ==="
+grep -r "scalafmt\|scalafix\|Xfatal-warnings" .github/ .circleci/ .buildkite/ 2>/dev/null | head -10
+
+echo "=== Compiler plugins ==="
+grep -r "addCompilerPlugin\|compilerPlugin\|semanticdb" build.sbt project/*.sbt 2>/dev/null | head -5
+
+echo "=== sbt plugins ==="
+cat project/plugins.sbt 2>/dev/null | grep -v "^$\|^//" | head -20
+```
+
+## Architecture
+### Framework Conventions
+- **Play Framework:** `app/controllers/`, `app/services/`, `app/models/`, `conf/routes` — MVC-ish with service layer
+- **Akka/Pekko:** Actor-based with typed actors, cluster sharding, event sourcing patterns
+- **http4s/tapir:** Functional HTTP with typed endpoints, middleware composition
+- **sbt multi-module:** `build.sbt` with `project(...)` definitions and `dependsOn` — compile-time boundary enforcement between modules
+- **Standard layout:** `src/main/scala/`, `src/test/scala/`, `src/it/scala/` (integration tests)
+
+### Evidence Commands
+```bash
+echo "=== Play Framework structure ==="
+ls app/controllers/ app/services/ app/models/ app/repositories/ conf/routes 2>/dev/null | head -5
+
+echo "=== sbt sub-projects ==="
+grep -r "lazy val\|\.dependsOn\|project(" build.sbt 2>/dev/null | head -15
+
+echo "=== Module directories ==="
+find . -maxdepth 2 -name "build.sbt" -not -path "*/target/*" 2>/dev/null
+
+echo "=== Directory structure ==="
+find . -maxdepth 3 -type d -not -path "*/target/*" -not -path "*/.git/*" -not -path "*/node_modules/*" 2>/dev/null | sort | head -40
+
+echo "=== Domain subdirectories in services ==="
+find . -path "*/services/*" -type d -not -path "*/target/*" 2>/dev/null | head -20
+
+echo "=== Domain subdirectories in controllers ==="
+find . -path "*/controllers/*" -type d -not -path "*/target/*" 2>/dev/null | head -20
+```
+
+### Co-Change Notes
+- **Expected Scala co-changes (NOT bad coupling):**
+  - Controller + service + repository for the same feature
+  - Model + database evolution/migration
+  - Protobuf definition + generated code
+  - Routes file changes alongside controller additions
+  - `build.sbt` churn on dependency updates
+- **High churn files to exclude from coupling analysis:**
+  - `Tables.scala` (auto-generated Slick schema) — changes with every evolution
+  - `build.sbt` — changes with every dependency update
+  - `AppSpec.scala` or test registry files — changes when any new test is added
+  - `conf/routes` — changes with every new endpoint
+- These expected co-changes should NOT penalize the architecture score.
+
+## Change Safety
+### Tooling
+- **Feature flags:** LaunchDarkly Scala SDK, custom FeatureFlag objects, Unleash
+- **Database migrations:** Play evolutions (conf/evolutions/), Flyway, Liquibase
+- **Dependency management:** sbt with Scala Steward or Renovate
+
+### Evidence Commands
+```bash
+echo "=== Feature flags ==="
+grep -r "featureFlag\|FeatureFlag\|feature_flag\|isEnabled\|isActive" --include="*.scala" . 2>/dev/null \
+  | grep -v .git | grep -v target | grep -v test | grep -v spec | wc -l
+find . -name "FeatureFlag*" -o -name "*FeatureToggle*" 2>/dev/null \
+  | grep -v target | grep -v .git | head -5
+
+echo "=== Database evolutions/migrations ==="
+find . -path "*/evolutions/*" -name "*.sql" -not -path "*/target/*" 2>/dev/null | wc -l
+find . -path "*/migrations/*" -name "*.sql" -not -path "*/target/*" 2>/dev/null | wc -l
+
+echo "=== Evolution rollback sections ==="
+grep -rl "!Downs" --include="*.sql" . 2>/dev/null | grep -v target | wc -l
+
+echo "=== Irreversible operations ==="
+grep -r "DROP TABLE\|DROP COLUMN\|ALTER.*DROP" --include="*.sql" . 2>/dev/null \
+  | grep -v target | head -10
+
+echo "=== sbt sub-projects (module boundaries) ==="
+grep -r "dependsOn\|project(" build.sbt 2>/dev/null | head -10
+```

--- a/plugins/codebase-readiness/skills/codebase-readiness/references/languages/typescript.md
+++ b/plugins/codebase-readiness/skills/codebase-readiness/references/languages/typescript.md
@@ -1,0 +1,171 @@
+# TypeScript — Language-Specific Assessment Criteria
+
+## Language Classification
+- **Tier:** statically-typed
+- **Primary safety mechanism:** Compile-time type checking via tsc with strict mode configuration
+- **Key principle:** TypeScript's value scales directly with strictness configuration; strict mode ON is the baseline expectation for a well-typed codebase.
+
+## Type Safety
+### What to Examine
+- tsconfig.json strict mode and related flags (noImplicitAny, strictNullChecks, strictFunctionTypes)
+- `any` type usage frequency — lower is better; measure as percentage of total type annotations
+- Runtime validation libraries: Zod, io-ts, class-validator for boundaries (API inputs, external data)
+- CI enforcement of type checking (tsc --noEmit in CI pipeline)
+
+### Evidence Commands
+```bash
+echo "=== tsconfig strict settings ==="
+cat tsconfig.json 2>/dev/null | grep -A5 -i '"strict\|compilerOptions'
+grep -r '"strict":\s*true\|"noImplicitAny"' tsconfig*.json 2>/dev/null
+
+echo "=== any usage count ==="
+grep -r ": any\|as any\|<any>" --include="*.ts" --include="*.tsx" . 2>/dev/null \
+  | grep -v node_modules | grep -v .git | grep -v ".d.ts" | wc -l
+
+echo "=== Total TS files (for any-ratio context) ==="
+find . -name "*.ts" -o -name "*.tsx" 2>/dev/null | grep -v node_modules | grep -v .git | wc -l
+
+echo "=== Runtime validation ==="
+grep -r "\"zod\"\|\"io-ts\"\|\"class-validator\"\|\"superstruct\"" package.json 2>/dev/null
+
+echo "=== CI type checking ==="
+grep -r "tsc\|type-check\|typecheck" .github/ .circleci/ .buildkite/ package.json 2>/dev/null | head -5
+```
+
+### Scoring Criteria
+- **0-20**: No strict mode, widespread `any`, no runtime validation
+- **21-40**: Strict mode off or partially configured, frequent `any` usage
+- **41-60**: Strict mode on, but no runtime validation at boundaries
+- **61-80**: Strict mode + runtime validation in critical paths (API boundaries, external data), CI enforced
+- **81-100**: Strict mode + comprehensive runtime validation + CI enforcement + `any` usage <5% of annotations
+
+### Language-Specific Notes
+- `any` is the primary escape hatch in TypeScript; its frequency is a direct measure of type safety holes.
+- Runtime validation (Zod, io-ts) at API boundaries is critical because TypeScript types are erased at runtime.
+- Check for `@ts-ignore` and `@ts-expect-error` comments as additional escape hatch indicators.
+
+## Test Foundation
+### Tooling & Detection
+- **Framework:** Jest (jest.config.*), Vitest (vitest.config.*)
+- **Coverage:** jest --coverage, coverageThreshold in jest.config; c8/istanbul for Vitest
+- **Mutation testing:** Stryker (@stryker-mutator/*)
+- **Property-based testing:** fast-check
+
+### Evidence Commands
+```bash
+echo "=== Test framework ==="
+ls jest.config.* vitest.config.* 2>/dev/null
+grep -r "\"jest\"\|\"vitest\"" package.json 2>/dev/null | head -5
+
+echo "=== Coverage config ==="
+grep -r "coverageThreshold\|collectCoverage" jest.config.* vitest.config.* 2>/dev/null | head -5
+grep -r "coverage" .github/ .circleci/ .buildkite/ 2>/dev/null | head -5
+
+echo "=== Mutation testing ==="
+grep -r "stryker" package.json 2>/dev/null
+
+echo "=== Property-based testing ==="
+grep -r "fast-check" package.json 2>/dev/null
+
+echo "=== Skipped tests ==="
+grep -r "\.skip\|xit\|xdescribe\|xtest" --include="*.test.*" --include="*.spec.*" . 2>/dev/null | grep -v node_modules | grep -v .git | wc -l
+
+echo "=== Mock density ==="
+grep -r "jest.fn\|jest.mock\|vi.fn\|vi.mock\|sinon" --include="*.test.*" --include="*.spec.*" . 2>/dev/null | grep -v node_modules | grep -v .git | wc -l
+
+echo "=== Test retry ==="
+grep -r "jest-circus\|retry\|retries" jest.config.* vitest.config.* 2>/dev/null | head -3
+```
+
+### Scoring Notes
+- **Skip patterns:** `.skip`, `xit`, `xdescribe`, `xtest`
+- **Mock indicators:** `jest.fn`, `jest.mock`, `vi.fn`, `vi.mock`, `sinon`
+- **Retry plugins:** jest retry, vitest retry configuration
+- TypeScript test files should themselves be well-typed; test files using `any` heavily indicate weak test quality
+
+## Feedback Loops
+### Tooling
+- **Pre-commit:** Husky (.husky/ directory), lint-staged
+- **Parallel test runner:** Jest workers (default), Vitest threads
+- **Security scanners:** npm audit, CodeQL, Snyk
+
+### Evidence Commands
+```bash
+echo "=== Pre-commit ==="
+ls .husky/ 2>/dev/null
+grep -r "husky\|lint-staged" package.json 2>/dev/null | head -5
+
+echo "=== Security ==="
+grep -r "npm audit\|snyk\|codeql" .github/ .circleci/ .buildkite/ 2>/dev/null | head -5
+```
+
+## Code Clarity
+### Conventions
+- **Extensions:** .ts, .tsx (React components)
+- **Idiomatic file size:** Varies by framework; components should be focused, utility files modular
+- **Naming:** camelCase for files/variables, PascalCase for components/classes/interfaces/types
+- **File organization:** Co-location of component + test + styles is common in React codebases
+
+## Consistency & Conventions
+### Tooling
+- **Linter:** ESLint (.eslintrc.*, eslint.config.*)
+- **Formatter:** Prettier (.prettierrc*, .prettierignore)
+- **Custom rules:** Custom ESLint rules or plugins for project-specific patterns
+
+### Evidence Commands
+```bash
+echo "=== ESLint config ==="
+ls .eslintrc.* eslint.config.* 2>/dev/null
+grep -r "eslint" .github/ .circleci/ .buildkite/ 2>/dev/null | head -5
+
+echo "=== Prettier config ==="
+ls .prettierrc* .prettierignore 2>/dev/null
+
+echo "=== Custom ESLint plugins ==="
+grep -r "eslint-plugin\|eslint-rule" package.json 2>/dev/null | head -5
+find . -name "*.js" -path "*eslint*" -not -path "*/node_modules/*" 2>/dev/null | head -5
+```
+
+## Architecture
+### Framework Conventions
+- **Next.js:** pages/ or app/ directory, API routes, components/
+- **Express:** routes/, controllers/, middleware/
+- **Monorepo:** packages/, apps/, libs/ (Turborepo, Nx, Lerna)
+- **General:** src/ directory as source root
+
+### Evidence Commands
+```bash
+echo "=== Framework detection ==="
+grep -r "\"next\"\|\"express\"\|\"fastify\"\|\"nestjs\"" package.json 2>/dev/null | head -5
+
+echo "=== Monorepo structure ==="
+find . -maxdepth 3 -name "package.json" 2>/dev/null | grep -v node_modules | grep -v .git | wc -l
+ls packages/ apps/ libs/ modules/ 2>/dev/null
+
+echo "=== Directory structure ==="
+find . -maxdepth 2 -type d 2>/dev/null | grep -v node_modules | grep -v .git | head -20
+
+echo "=== Circular dependency indicators ==="
+grep -r "import.*from.*\.\.\/" --include="*.ts" --include="*.tsx" . 2>/dev/null | grep -v node_modules | grep -v .git | wc -l
+```
+
+### Co-Change Notes
+- package-lock.json / yarn.lock churn is expected and should not penalize
+- In monorepos, shared package changes triggering consumer updates is expected
+- Next.js page + API route co-changes for the same feature are expected
+
+## Change Safety
+### Tooling
+- **Feature flags:** LaunchDarkly, Unleash, custom feature-flags packages, environment-based flags
+- **Database migrations:** Prisma migrations, TypeORM migrations, Knex migrations
+
+### Evidence Commands
+```bash
+echo "=== Feature flags ==="
+grep -r "launchdarkly\|unleash\|feature-flag\|featureFlag" package.json 2>/dev/null | head -5
+grep -r "featureFlag\|feature_flag\|isEnabled\|isFeatureEnabled" --include="*.ts" --include="*.tsx" . 2>/dev/null | grep -v node_modules | grep -v .git | grep -v test | wc -l
+
+echo "=== Database migrations ==="
+find . -path "*/migrations/*" -name "*.ts" 2>/dev/null | grep -v node_modules | grep -v .git | wc -l
+ls prisma/migrations/ 2>/dev/null
+```


### PR DESCRIPTION
## Summary

- Adds a new `codebase-readiness` plugin that scores codebases across 8 dimensions for AI agent-readiness
- Framed around the Stripe benchmark of 1,000+ AI-generated PRs per week as a non-political external standard
- Uses the parallel-code-review pattern: orchestrator skill gathers metadata, then launches 4 specialized agents concurrently

## How It Works

**Phase 1** — Orchestrator runs shell commands to build a Codebase Snapshot (language, size, CI config, docs, lint)

**Phase 2** — 4 agents launch in parallel, each assessing 2-3 related dimensions:
- `test-coverage-assessor` → Test Foundation (20%) + Feedback Loops (5%)
- `documentation-assessor` → Documentation & Context (15%)
- `code-clarity-assessor` → Code Clarity (15%) + Consistency & Conventions (10%)
- `architecture-assessor` → Type Safety (15%) + Architecture Clarity (15%) + Change Safety (5%)

**Phase 3-4** — Weighted score (0-100) calculated, band rating assigned, full report assembled with improvement roadmap

**Phase 5** — Offers to save report as `AGENT_READY_ASSESSMENT.md`

## Score Bands

| Score | Band | Meaning |
|-------|------|---------|
| 85-100 | Agent-Ready | Autonomous agent work |
| 70-84 | Agent-Assisted | Agents with human oversight |
| 50-69 | Agent-Supervised | Heavy review needed |
| 30-49 | Agent-Caution | Foundational work first |
| 0-29 | Not Agent-Ready | Significant investment required |

## Test Plan

- [ ] `cd` to any existing project and invoke: "Run a codebase readiness assessment"
- [ ] Verify Phase 1 reconnaissance runs and produces a readable Codebase Snapshot
- [ ] Verify 4 agents launch in parallel and return scored dimension reports
- [ ] Verify final report includes weighted score table, band rating, and improvement roadmap
- [ ] Verify save-to-file prompt produces valid `AGENT_READY_ASSESSMENT.md`
- [ ] Verify plugin appears in `/plugin marketplace list`