### PR TITLE
fix: remove trailing comma in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -46,6 +46,6 @@
       "source": "./plugins/gridfinity-planner",
       "description": "Plan and design gridfinity baseplates for 3D printing with optimal grid layouts",
       "version": "1.1.0"
-    },
+    }
   ]
 }


### PR DESCRIPTION
 ## Summary

`marketplace.json` contained a trailing comma after the last entry in the plugins array, making it invalid JSON and preventing users from adding the plugins via Claude Code Marketplace. This fix ensures the file parses correctly and ensures the Claude Code command to add the plugins works as intended.

## Changes

  - Removed trailing comma from the plugins array in `.claude-plugin/marketplace.json`