### PR TITLE
Add CLAUDE.md and ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,84 @@
+# Architecture
+
+## Design Philosophy
+
+This repository treats the **repository as the system of record** for agent capabilities. Every skill, agent definition, and workflow lives in-repo as versioned, structured artifacts that agents can discover and reason about directly.
+
+The architecture follows the principle of **progressive disclosure** — agents encounter a small, stable entry point (SKILL.md frontmatter) and are taught where to look next (the SKILL.md body, then references, then scripts and assets), rather than being overwhelmed up front.
+
+## Component Map
+
+### Plugin Marketplace (`.claude-plugin/marketplace.json`)
+
+The single registry that maps plugin names to their source directories and versions. This is what Claude Code reads when users run `/plugin marketplace add` or `/plugin install`.
+
+### Plugins (`plugins/`)
+
+Each plugin is self-contained and independently installable. A plugin can contain one or more skills, agents, or commands.
+
+```
+plugins/<name>/
+├── .claude-plugin/plugin.json   ← identity + version
+├── README.md                    ← user-facing docs
+└── skills/<skill-name>/
+    ├── SKILL.md                 ← the skill itself
+    ├── scripts/                 ← deterministic, executable code
+    ├── references/              ← documentation loaded into context as needed
+    └── assets/                  ← files used in output (templates, images)
+```
+
+**Why this structure matters:** Skills use a three-level loading system to manage context efficiently:
+
+1. **Metadata** (name + description from frontmatter) — always in context (~100 words)
+2. **SKILL.md body** — loaded when the skill triggers (<5k words)
+3. **Bundled resources** (references, scripts, assets) — loaded as needed by the agent
+
+This mirrors the progressive disclosure pattern: agents start with a lightweight map and drill deeper only when needed, preserving context window for the actual task.
+
+### Skill Resources
+
+- **Scripts** (`scripts/`) — Code that would otherwise be rewritten every invocation. Token-efficient because scripts can be executed without being read into context. Example: `recon.sh` in codebase-readiness gathers project metadata deterministically.
+
+- **References** (`references/`) — Domain knowledge loaded into context when the agent determines it's needed. Keeps SKILL.md lean while making deep knowledge discoverable. Example: codebase-readiness stores language-specific scoring rubrics (Ruby, Python, TypeScript, etc.) and dimension guides as separate reference files.
+
+- **Assets** (`assets/`) — Files used in output, not loaded into context. Templates, images, boilerplate that get copied or modified. Example: report templates that agents fill in with assessment results.
+
+### Supporting Content
+
+- **`configs/`** — Opinionated Claude Code configuration recommendations (status bar, MCP servers)
+- **`tips/`** — Short-form guides for Claude Code workflows (worktrees, subagents, context management)
+- **`scripts/`** — Utility scripts not tied to a specific plugin
+
+### CI Validation (`.github/workflows/`)
+
+Enforces structural invariants mechanically:
+
+- **Skill validation** — Checks SKILL.md frontmatter format, required fields, naming conventions on every PR
+- **JSON validation** — Ensures all plugin.json and marketplace.json files are syntactically valid
+
+These checks encode "taste" as enforceable rules — agents and contributors can ship fast without undermining structural consistency.
+
+## Invariants
+
+These rules are enforced either by CI or by convention:
+
+1. **Every plugin has a plugin.json** with name, version, description
+2. **Every skill has a SKILL.md** with valid frontmatter (name + description)
+3. **Versions are synchronized** between plugin.json and marketplace.json
+4. **Skill names are kebab-case**, max 64 characters
+5. **No stale JSON** — all JSON files parse cleanly
+6. **Skills are self-contained** — a plugin directory contains everything needed to use it
+
+## Design Decisions
+
+### Why plugins over a monolithic skill collection?
+
+Plugins are independently installable and versionable. A user who only needs TDD workflow doesn't pull in meeting transcript processing. This also allows different release cadences per plugin.
+
+### Why reference files instead of large SKILL.md files?
+
+Context is a scarce resource. A 2,000-line SKILL.md crowds out the actual task. Reference files let agents load only what's relevant — a Ruby assessment doesn't need to read the Scala rubric. This follows the same principle described in OpenAI's [Harness Engineering](https://openai.com/index/harness-engineering/) post: "give the agent a map, not a 1,000-page instruction manual."
+
+### Why enforce structure in CI?
+
+Documentation alone doesn't keep a growing plugin ecosystem coherent. Mechanical enforcement catches drift before it compounds — the same principle behind custom linters in agent-first codebases. A broken frontmatter field means the skill won't trigger correctly; catching it in CI is cheaper than debugging it in production.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# Claude Code Workflows
+
+A plugin marketplace for Claude Code — skills, agents, and bundles that extend Claude's capabilities with specialized workflows.
+
+For architecture details, design decisions, and the reasoning behind the plugin structure, see [ARCHITECTURE.md](ARCHITECTURE.md).
+
+## Repository Structure
+
+```
+plugins/                        # Each subdirectory is a standalone plugin
+  <plugin-name>/
+    .claude-plugin/plugin.json  # Name, version, description, author
+    README.md                   # User-facing documentation
+    skills/<skill-name>/
+      SKILL.md                  # Frontmatter + instructions (required)
+      scripts/                  # Executable code (optional)
+      references/               # Docs loaded into context as needed (optional)
+      assets/                   # Templates, files used in output (optional)
+.claude-plugin/marketplace.json # Registry of all available plugins
+.agents/skills/                 # Locally installed skills (e.g., skill-creator)
+configs/                        # Claude Code configuration guides
+tips/                           # Short-form workflow guides
+scripts/                        # Utility scripts
+```
+
+## Key Conventions
+
+- Plugin versions live in two places — bump both `plugins/<name>/.claude-plugin/plugin.json` AND `.claude-plugin/marketplace.json`
+- SKILL.md frontmatter requires `name` (kebab-case, max 64 chars) and `description` (max 1024 chars, no angle brackets)
+- Skill instructions use imperative/infinitive form, not second person
+- All JSON files must be valid — CI checks this automatically
+- Commit messages follow conventional commits: `feat:`, `fix:`, `chore:`, `docs:`
+
+## Development Workflow
+
+1. Create or modify plugins under `plugins/`
+2. Validate locally: `python3 .agents/skills/skill-creator/scripts/quick_validate.py plugins/<name>/skills/<skill-name>`
+3. CI validates skills and JSON on PRs automatically
+4. Bump version in both plugin.json and marketplace.json before merging
+
+## Adding a New Plugin
+
+1. Create `plugins/<name>/.claude-plugin/plugin.json` with name, version, description, author
+2. Create `plugins/<name>/skills/<skill-name>/SKILL.md` with frontmatter and instructions
+3. Add the plugin entry to `.claude-plugin/marketplace.json`
+4. Add a `plugins/<name>/README.md` for users


### PR DESCRIPTION
## Summary

- **CLAUDE.md** — Operational map for agents and contributors: repo structure, key conventions, development workflow, how to add a plugin. Points to ARCHITECTURE.md for deeper context.
- **ARCHITECTURE.md** — Design philosophy and decisions: progressive disclosure pattern, three-level skill loading system, why plugins are self-contained, why CI enforces invariants. References OpenAI's Harness Engineering post on repo-as-system-of-record.

A plugin marketplace about agent-readiness should practice what it preaches.

## Test plan

- [x] CLAUDE.md references ARCHITECTURE.md for progressive disclosure
- [x] Both files are concise and agent-optimized (no bloat)
- [ ] Verify agents can discover and use these docs when working in the repo