### PR TITLE
feat: add doc-sentinel plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -69,7 +69,7 @@
       "name": "doc-sentinel",
       "source": "./plugins/doc-sentinel",
       "description": "Proactive documentation drift detector. Hooks into commits to identify docs referencing changed code, flags drift before staleness accumulates, and resolves warnings via targeted fixes.",
-      "version": "1.0.0"
+      "version": "1.0.5"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -64,6 +64,12 @@
       "source": "./plugins/doc-audit",
       "description": "Audit codebase documentation for accuracy, completeness, and freshness against actual code. Auto-fixes small discrepancies, reports structural changes. Companion to agent-ready.",
       "version": "1.0.0"
+    },
+    {
+      "name": "doc-sentinel",
+      "source": "./plugins/doc-sentinel",
+      "description": "Proactive documentation drift detector. Hooks into commits to identify docs referencing changed code, flags drift before staleness accumulates, and resolves warnings via targeted fixes.",
+      "version": "1.0.0"
     }
   ]
 }

--- a/plugins/doc-sentinel/.claude-plugin/plugin.json
+++ b/plugins/doc-sentinel/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "doc-sentinel",
+  "version": "1.0.0",
+  "description": "Proactive documentation drift detector. Hooks into commits to identify docs referencing changed code, flags drift before staleness accumulates, and resolves warnings via targeted fixes.",
+  "author": {
+    "name": "Damian Galarza",
+    "url": "https://www.damiangalarza.com"
+  },
+  "repository": "https://github.com/dgalarza/claude-code-workflows",
+  "license": "MIT",
+  "keywords": [
+    "documentation",
+    "drift-detection",
+    "hooks",
+    "proactive",
+    "guardian",
+    "staleness",
+    "code-references",
+    "agent-ready"
+  ]
+}

--- a/plugins/doc-sentinel/.claude-plugin/plugin.json
+++ b/plugins/doc-sentinel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-sentinel",
-  "version": "1.0.0",
+  "version": "1.0.5",
   "description": "Proactive documentation drift detector. Hooks into commits to identify docs referencing changed code, flags drift before staleness accumulates, and resolves warnings via targeted fixes.",
   "author": {
     "name": "Damian Galarza",

--- a/plugins/doc-sentinel/README.md
+++ b/plugins/doc-sentinel/README.md
@@ -1,0 +1,181 @@
+# doc-sentinel
+
+Proactive documentation drift detector for Claude Code. Hooks into every commit to identify docs that reference changed code, flags drift before staleness accumulates, and resolves warnings with targeted fixes.
+
+## How It Fits
+
+The documentation lifecycle has three layers:
+
+| Layer | Plugin | When |
+|-------|--------|------|
+| **Scaffold** | [agent-ready](../agent-ready/) | One-time setup — creates AGENTS.md, ARCHITECTURE.md, docs/ |
+| **Write** | [doc-sync](../doc-sync/) | Continuous — generates and updates docs when code changes |
+| **Guard** | **doc-sentinel** | Continuous — catches when existing docs drift from code reality |
+| **Audit** | [doc-audit](../doc-audit/) | On-demand — full accuracy/freshness validation |
+
+doc-sync writes docs. doc-sentinel catches when those docs go wrong.
+
+## Quick Start
+
+```bash
+# 1. Configure what to watch
+/doc-sentinel:setup
+
+# 2. Run a baseline drift scan
+/doc-sentinel:scan
+
+# 3. Fix any drift found
+/doc-sentinel:resolve
+```
+
+After setup, hooks run automatically — no manual invocation needed for ongoing detection.
+
+## How It Works
+
+```
+Developer commits code
+    │
+    ▼
+PostToolUse hook fires (detects git commit)
+    ├─ Extracts changed source files
+    ├─ Scans all docs for references to those files
+    ├─ Cross-references: file paths, module names, directory paths
+    └─ Queues drift warnings to .doc-sentinel-drift.json
+    │
+    ▼
+Session continues (warnings accumulate)
+    │
+    ▼
+Stop hook fires (end of session)
+    ├─ Counts accumulated warnings
+    ├─ Summarizes affected docs
+    └─ Prompts: "Run /doc-sentinel:resolve to fix N drift warnings"
+    │
+    ▼
+/doc-sentinel:resolve
+    ├─ Groups warnings by doc file
+    ├─ Reads doc + source to classify drift
+    ├─ Fixes real drift, dismisses false positives
+    ├─ Dispatches drift-resolver agent for complex cases
+    └─ Commits with docs: prefix, clears queue
+```
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/doc-sentinel:setup` | Configure drift detection for the project |
+| `/doc-sentinel:scan` | Full-codebase drift scan (read-only) |
+| `/doc-sentinel:resolve` | Process and fix accumulated drift warnings |
+
+## What It Detects
+
+### Critical Drift (broken references)
+- File paths in docs that point to moved/deleted files
+- Directory references to restructured modules
+- Commands (pnpm scripts, etc.) that no longer exist
+
+### Stale References
+- Source files changed significantly since the doc was last updated
+- API endpoints or function signatures that evolved
+- Configuration values (ports, env vars) that shifted
+
+### Warnings
+- Port numbers in docs that conflict with docker-compose or .env
+- Env vars documented but not found in source
+- Symlink integrity (CLAUDE.md → AGENTS.md)
+
+## Configuration
+
+`.doc-sentinel.json` (created by `/doc-sentinel:setup`):
+
+```json
+{
+  "version": 1,
+  "docs_root": "docs",
+  "watch_files": ["AGENTS.md", "ARCHITECTURE.md", "README.md"],
+  "ignore_sources": ["*.test.*", "*.spec.*", "__tests__/**", "*.d.ts"],
+  "ignore_docs": [],
+  "severity": {
+    "architecture": "high",
+    "agents_md": "high",
+    "api_reference": "medium",
+    "changelog": "low",
+    "readme": "medium"
+  }
+}
+```
+
+| Field | Purpose |
+|-------|---------|
+| `docs_root` | Primary documentation directory |
+| `watch_files` | Additional doc files outside docs_root to monitor |
+| `ignore_sources` | Source file patterns to skip (tests, type defs) |
+| `ignore_docs` | Doc files to exclude from drift checks |
+| `severity` | Controls when drift is flagged (high/medium/low) |
+
+## Drift Queue Format
+
+`.doc-sentinel-drift.json` — ephemeral, session-scoped:
+
+```json
+[
+  {
+    "source": "src/routes/auth.ts",
+    "doc": "ARCHITECTURE.md",
+    "commit": "abc1234",
+    "message": "refactor: restructure auth module",
+    "timestamp": "2026-04-07T10:00:00Z"
+  }
+]
+```
+
+Add `.doc-sentinel-drift.json` to `.gitignore` — it is not meant to be committed.
+
+## Agents
+
+### drift-resolver
+
+Dispatched by `/doc-sentinel:resolve` for complex drift cases (>5 warnings per doc or multi-section updates). Reads both docs and source diffs, applies coordinated updates, and verifies coherence after changes.
+
+## Rules
+
+### doc-references
+
+Applied to all `.md` files. Encourages documentation practices that make drift detection reliable: backtick-quoted paths, relative references, co-located doc updates.
+
+## Companion Plugins
+
+doc-sentinel works alongside but does not conflict with:
+
+- **doc-sync / inkwell** — They generate docs; sentinel catches when those docs drift. Separate queue files, no interference.
+- **agent-ready** — Sentinel monitors the artifacts that agent-ready scaffolds (AGENTS.md, ARCHITECTURE.md).
+- **doc-audit** — Sentinel catches drift proactively; doc-audit provides periodic deep validation. Use both for comprehensive coverage.
+
+## Installation
+
+### From the marketplace
+
+```bash
+claude install dgalarza-workflows/doc-sentinel
+```
+
+### From local source
+
+```bash
+claude install ./plugins/doc-sentinel
+```
+
+### Manual
+
+Copy the `plugins/doc-sentinel/` directory into your project's `.claude/plugins/` directory.
+
+## Troubleshooting
+
+**Hook not firing:** Verify `hooks.json` is loaded — check Claude Code plugin settings. The PostToolUse hook only fires on Bash tool use containing `git commit`.
+
+**Too many false positives:** Tune `ignore_sources` in `.doc-sentinel.json` to skip files that docs reference generically (e.g., test files, generated types). The `resolve` skill lets you dismiss false positives.
+
+**Conflicts with doc-sync:** None expected — they use separate queue files (`.doc-sync-queue.json` vs `.doc-sentinel-drift.json`) and separate hook scripts. Both can be active simultaneously.
+
+**jq not installed:** The hook scripts have a fallback mode without jq, but functionality is limited (no config-driven ignore patterns, basic line-count reporting). Install jq for full drift detection: `brew install jq` / `apt install jq`.

--- a/plugins/doc-sentinel/agents/drift-resolver.md
+++ b/plugins/doc-sentinel/agents/drift-resolver.md
@@ -1,0 +1,71 @@
+---
+name: drift-resolver
+description: Resolves complex documentation drift requiring multi-file analysis and coordinated updates
+tools: Read, Bash, Glob, Grep, Write, Edit
+model: inherit
+---
+
+# drift-resolver
+
+Dispatched by `/doc-sentinel:resolve` when a doc file has extensive drift (>5 warnings from a single commit or changes spanning multiple sections). Handles cases too complex for inline resolution.
+
+## Input
+
+Receives context about:
+- The doc file to update
+- The source files that changed
+- The specific drift warnings (from `.doc-sentinel-drift.json`)
+- The commit messages explaining what changed
+
+## Process
+
+### Step 1: Understand the Doc
+
+Read the full doc file. Identify its structure — sections, tables, code blocks, path references, command examples.
+
+### Step 2: Map Changes
+
+For each changed source file:
+- Read the current version
+- Run `git diff HEAD~1 -- <file>` to see exactly what changed
+- Note which doc sections reference this file
+
+### Step 3: Targeted Updates
+
+Update each affected section:
+
+- **Path references** — find-and-replace old paths with new paths
+- **Code examples** — update to reflect new function signatures, imports, or usage
+- **Tables** (ports, env vars, commands) — update affected rows, add new entries, remove defunct ones
+- **Prose descriptions** — rewrite sentences that describe changed behavior. Match surrounding style.
+- **Architecture diagrams** (ASCII/Mermaid) — update component names, connections, or flow descriptions
+
+### Step 4: Coherence Check
+
+After all updates, re-read the doc to verify:
+- No orphaned references to old names/paths
+- Tables are internally consistent (no duplicate rows, correct counts)
+- Cross-references to other docs still valid
+- Section ordering still makes sense
+
+### Step 5: Stage Changes
+
+```bash
+git add <updated-doc-files>
+```
+
+Do NOT commit — the parent `/doc-sentinel:resolve` skill handles the commit.
+
+## Budget
+
+- Max 10 source files analyzed per invocation
+- Max 15 Bash calls
+- Max 3 doc files updated per invocation
+
+## Rules
+
+- Never modify source code — only documentation
+- Preserve existing heading structure (do not reorganize sections)
+- When uncertain about behavioral changes, add `<!-- doc-sentinel: verify this description -->` rather than guessing
+- Match the existing doc's level of detail — do not add excessive prose to a terse doc or strip detail from a thorough one
+- If the doc references files that no longer exist and there is no clear replacement, mark with `<!-- doc-sentinel: file removed, verify replacement -->` instead of deleting the reference

--- a/plugins/doc-sentinel/hooks/hooks.json
+++ b/plugins/doc-sentinel/hooks/hooks.json
@@ -1,0 +1,29 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/post-commit-drift.sh",
+            "timeout": 5000,
+            "statusMessage": "doc-sentinel: scanning for documentation drift..."
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/stop-drift-report.sh",
+            "timeout": 5000,
+            "statusMessage": "doc-sentinel: checking drift warnings..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/doc-sentinel/hooks/hooks.json
+++ b/plugins/doc-sentinel/hooks/hooks.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/post-commit-drift.sh",
-            "timeout": 5000,
+            "timeout": 10,
             "statusMessage": "doc-sentinel: scanning for documentation drift..."
           }
         ]
@@ -19,7 +19,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/stop-drift-report.sh",
-            "timeout": 5000,
+            "timeout": 10,
             "statusMessage": "doc-sentinel: checking drift warnings..."
           }
         ]

--- a/plugins/doc-sentinel/hooks/post-commit-drift.sh
+++ b/plugins/doc-sentinel/hooks/post-commit-drift.sh
@@ -5,6 +5,16 @@
 
 set -euo pipefail
 
+# ─── Resolve project root ────────────────────────────────────────────────────
+# Hooks may run from any subdirectory of the project. Always resolve paths
+# relative to $CLAUDE_PROJECT_DIR (set by Claude Code), falling back to
+# `git rev-parse` for environments that skipped the export.
+PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || true)}"
+if [ -z "$PROJECT_ROOT" ]; then
+  exit 0
+fi
+cd "$PROJECT_ROOT"
+
 # ─── Fast pre-filter ─────────────────────────────────────────────────────────
 # Read the tool input from stdin. Skip if not a git commit.
 INPUT=$(cat)
@@ -32,9 +42,9 @@ if printf '%s\n' "$COMMIT_MSG" | grep -qE '^docs(\(.+\))?:'; then
 fi
 
 # ─── Configuration ────────────────────────────────────────────────────────────
-CONFIG_FILE=".doc-sentinel.json"
-DRIFT_FILE=".doc-sentinel-drift.json"
-DOC_ROOT="docs"
+CONFIG_FILE="$PROJECT_ROOT/.doc-sentinel.json"
+DRIFT_FILE="$PROJECT_ROOT/.doc-sentinel-drift.json"
+DOC_ROOT="$PROJECT_ROOT/docs"
 EXTRA_DOCS=""
 
 if [ -f "$CONFIG_FILE" ] && command -v jq &>/dev/null; then
@@ -64,8 +74,16 @@ if [ -f "$CONFIG_FILE" ] && command -v jq &>/dev/null; then
       SKIP=false
       while IFS= read -r pattern; do
         [ -z "$pattern" ] && continue
-        # Convert glob to regex: *.test.* → .*\.test\..*
-        REGEX=$(printf '%s' "$pattern" | sed 's/\./\\./g; s/\*\*/DOUBLESTAR/g; s/\*/[^/]*/g; s/DOUBLESTAR/.*/g')
+        # Convert glob to regex. Use `#` as sed delimiter — BSD sed (macOS)
+        # mis-parses `/` inside the replacement of `s/old/new/g`. Order matters:
+        # `?` must be expanded before `**/` becomes `(.*/)?` so the regex `?`
+        # quantifier isn't clobbered by the glob `?` → `.` rule.
+        REGEX=$(printf '%s' "$pattern" | sed -e 's#\.#\\.#g' \
+                                              -e 's#?#.#g' \
+                                              -e 's#\*\*/#DBLSTARSLASH#g' \
+                                              -e 's#\*\*#.*#g' \
+                                              -e 's#\*#[^/]*#g' \
+                                              -e 's#DBLSTARSLASH#(.*/)?#g')
         if printf '%s\n' "$src_file" | grep -qE "(^|/)${REGEX}$"; then
           SKIP=true
           break
@@ -91,16 +109,16 @@ fi
 
 # Add top-level doc files
 for f in AGENTS.md ARCHITECTURE.md CLAUDE.md README.md; do
-  if [ -f "$f" ]; then
-    DOC_FILES=$(printf '%s\n%s' "$DOC_FILES" "$f")
+  if [ -f "$PROJECT_ROOT/$f" ]; then
+    DOC_FILES=$(printf '%s\n%s' "$DOC_FILES" "$PROJECT_ROOT/$f")
   fi
 done
 
 # Add extra watched files from config
 if [ -n "$EXTRA_DOCS" ]; then
   while IFS= read -r extra; do
-    if [ -f "$extra" ]; then
-      DOC_FILES=$(printf '%s\n%s' "$DOC_FILES" "$extra")
+    if [ -f "$PROJECT_ROOT/$extra" ]; then
+      DOC_FILES=$(printf '%s\n%s' "$DOC_FILES" "$PROJECT_ROOT/$extra")
     fi
   done <<< "$EXTRA_DOCS"
 fi

--- a/plugins/doc-sentinel/hooks/post-commit-drift.sh
+++ b/plugins/doc-sentinel/hooks/post-commit-drift.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# doc-sentinel: PostToolUse hook for Bash
+# Detects git commits, finds docs referencing changed files, queues drift warnings.
+# Must complete in <2s. Exits cleanly on all errors.
+
+set -euo pipefail
+
+# ─── Fast pre-filter ─────────────────────────────────────────────────────────
+# Read the tool input from stdin. Skip if not a git commit.
+INPUT=$(cat)
+if ! printf '%s\n' "$INPUT" | grep -q 'git commit'; then
+  exit 0
+fi
+
+# If jq is available, check the actual command (not just surrounding text)
+if command -v jq &>/dev/null; then
+  COMMAND=$(jq -r '.tool_input.command // empty' <<< "$INPUT")
+  if ! printf '%s\n' "$COMMAND" | grep -qE 'git commit'; then
+    exit 0
+  fi
+fi
+
+# ─── Skip docs-only commits ──────────────────────────────────────────────────
+COMMIT_MSG=$(git log -1 --pretty=format:"%s" 2>/dev/null || echo "")
+if [ -z "$COMMIT_MSG" ]; then
+  exit 0
+fi
+
+# Skip docs: prefix commits to avoid feedback loops
+if printf '%s\n' "$COMMIT_MSG" | grep -qE '^docs(\(.+\))?:'; then
+  exit 0
+fi
+
+# ─── Configuration ────────────────────────────────────────────────────────────
+CONFIG_FILE=".doc-sentinel.json"
+DRIFT_FILE=".doc-sentinel-drift.json"
+DOC_ROOT="docs"
+EXTRA_DOCS=""
+
+if [ -f "$CONFIG_FILE" ] && command -v jq &>/dev/null; then
+  DOC_ROOT=$(jq -r '.docs_root // "docs"' "$CONFIG_FILE")
+  EXTRA_DOCS=$(jq -r '.watch_files // [] | .[]' "$CONFIG_FILE" 2>/dev/null || echo "")
+fi
+
+# ─── Get changed files from the last commit ──────────────────────────────────
+CHANGED_FILES=$(git diff-tree --no-commit-id --name-only -r HEAD 2>/dev/null || echo "")
+if [ -z "$CHANGED_FILES" ]; then
+  exit 0
+fi
+
+# Filter to source files only (skip docs, configs, lockfiles)
+SOURCE_FILES=$(echo "$CHANGED_FILES" | grep -vE '\.(md|txt|json|lock|yaml|yml|toml)$' | grep -vE '^(docs/|\.github/|\.vscode/)' || true)
+if [ -z "$SOURCE_FILES" ]; then
+  exit 0
+fi
+
+# Apply ignore_sources patterns from config
+if [ -f "$CONFIG_FILE" ] && command -v jq &>/dev/null; then
+  IGNORE_PATTERNS=$(jq -r '.ignore_sources // [] | .[]' "$CONFIG_FILE" 2>/dev/null || echo "")
+  if [ -n "$IGNORE_PATTERNS" ]; then
+    FILTERED=""
+    while IFS= read -r src_file; do
+      [ -z "$src_file" ] && continue
+      SKIP=false
+      while IFS= read -r pattern; do
+        [ -z "$pattern" ] && continue
+        # Convert glob to regex: *.test.* → .*\.test\..*
+        REGEX=$(printf '%s' "$pattern" | sed 's/\./\\./g; s/\*\*/DOUBLESTAR/g; s/\*/[^/]*/g; s/DOUBLESTAR/.*/g')
+        if printf '%s\n' "$src_file" | grep -qE "(^|/)${REGEX}$"; then
+          SKIP=true
+          break
+        fi
+      done <<< "$IGNORE_PATTERNS"
+      if [ "$SKIP" = false ]; then
+        FILTERED=$(printf '%s\n%s' "$FILTERED" "$src_file")
+      fi
+    done <<< "$SOURCE_FILES"
+    SOURCE_FILES=$(echo "$FILTERED" | sed '/^$/d')
+    if [ -z "$SOURCE_FILES" ]; then
+      exit 0
+    fi
+  fi
+fi
+
+# ─── Find docs that reference changed files ───────────────────────────────────
+# Build a list of doc files to scan
+DOC_FILES=""
+if [ -d "$DOC_ROOT" ]; then
+  DOC_FILES=$(find "$DOC_ROOT" -name '*.md' -type f 2>/dev/null || true)
+fi
+
+# Add top-level doc files
+for f in AGENTS.md ARCHITECTURE.md CLAUDE.md README.md; do
+  if [ -f "$f" ]; then
+    DOC_FILES=$(printf '%s\n%s' "$DOC_FILES" "$f")
+  fi
+done
+
+# Add extra watched files from config
+if [ -n "$EXTRA_DOCS" ]; then
+  while IFS= read -r extra; do
+    if [ -f "$extra" ]; then
+      DOC_FILES=$(printf '%s\n%s' "$DOC_FILES" "$extra")
+    fi
+  done <<< "$EXTRA_DOCS"
+fi
+
+if [ -z "$DOC_FILES" ]; then
+  exit 0
+fi
+
+# ─── Cross-reference: which docs mention changed source files? ────────────────
+DRIFT_WARNINGS=""
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+COMMIT_HASH=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+DOC_FILE_LIST=$(echo "$DOC_FILES" | sed '/^$/d' | sort -u)
+
+while IFS= read -r src_file; do
+  [ -z "$src_file" ] && continue
+
+  # Generate search patterns from the file path
+  # Match: full path, filename, or module name (without extension)
+  BASENAME=$(basename "$src_file")
+  MODULE_NAME="${BASENAME%.*}"
+
+  # Search all doc files at once with grep -l (one process instead of N)
+  MATCHING_DOCS=$(echo "$DOC_FILE_LIST" | xargs grep -lE "(${src_file}|${BASENAME}|${MODULE_NAME})" 2>/dev/null || true)
+  MATCHING_DOCS=$(echo "$MATCHING_DOCS" | sed '/^$/d' | sort -u)
+  if [ -n "$MATCHING_DOCS" ]; then
+    while IFS= read -r doc; do
+      [ -z "$doc" ] && continue
+      # Build JSON warning entry (without jq for speed)
+      DRIFT_WARNINGS=$(printf '%s{"source":"%s","doc":"%s","commit":"%s","message":"%s","timestamp":"%s"}\n' \
+        "$DRIFT_WARNINGS" "$src_file" "$doc" "$COMMIT_HASH" "$COMMIT_MSG" "$TIMESTAMP")
+    done <<< "$MATCHING_DOCS"
+  fi
+done <<< "$SOURCE_FILES"
+
+if [ -z "$DRIFT_WARNINGS" ]; then
+  exit 0
+fi
+
+# ─── Append to drift file ────────────────────────────────────────────────────
+# Use jq if available for clean JSON, otherwise append raw
+if command -v jq &>/dev/null; then
+  # Build a JSON array from the warnings
+  WARNINGS_JSON=$(echo "$DRIFT_WARNINGS" | sed '/^$/d' | jq -s '.')
+
+  if [ -f "$DRIFT_FILE" ]; then
+    EXISTING=$(jq '.' "$DRIFT_FILE" 2>/dev/null || echo "[]")
+    echo "$EXISTING" | jq --argjson new "$WARNINGS_JSON" '. + $new' > "$DRIFT_FILE"
+  else
+    echo "$WARNINGS_JSON" > "$DRIFT_FILE"
+  fi
+else
+  # Fallback: append line-delimited JSON
+  echo "$DRIFT_WARNINGS" >> "$DRIFT_FILE"
+fi
+
+WARNING_COUNT=$(echo "$DRIFT_WARNINGS" | sed '/^$/d' | wc -l | tr -d ' ')
+UNIQUE_DOCS=$(echo "$DRIFT_WARNINGS" | sed '/^$/d' | grep -oE '"doc":"[^"]*"' | sort -u | wc -l | tr -d ' ')
+
+# Output status for the hook system
+echo "doc-sentinel: ${WARNING_COUNT} drift warning(s) across ${UNIQUE_DOCS} doc(s) from commit ${COMMIT_HASH}"

--- a/plugins/doc-sentinel/hooks/stop-drift-report.sh
+++ b/plugins/doc-sentinel/hooks/stop-drift-report.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# doc-sentinel: Stop hook
+# Checks for accumulated drift warnings and prompts resolution.
+# Exits cleanly on all errors.
+
+set -euo pipefail
+
+DRIFT_FILE=".doc-sentinel-drift.json"
+
+# No drift file — nothing to do
+if [ ! -f "$DRIFT_FILE" ]; then
+  exit 0
+fi
+
+# Check for jq
+if ! command -v jq &>/dev/null; then
+  # Fallback: count lines
+  WARNING_COUNT=$(wc -l < "$DRIFT_FILE" | tr -d ' ')
+  if [ "$WARNING_COUNT" -eq 0 ]; then
+    exit 0
+  fi
+
+  cat <<RESP
+{
+  "hookSpecificOutput": {
+    "hookEventName": "Stop",
+    "systemMessage": "doc-sentinel: ${WARNING_COUNT} documentation drift warning(s) detected during this session. Run /doc-sentinel:resolve to review and fix affected docs, or /doc-sentinel:scan for a full drift report."
+  }
+}
+RESP
+  exit 0
+fi
+
+# Parse with jq
+WARNING_COUNT=$(jq 'length' "$DRIFT_FILE" 2>/dev/null || echo "0")
+if [ "$WARNING_COUNT" -eq 0 ] || [ "$WARNING_COUNT" = "null" ]; then
+  exit 0
+fi
+
+# Build summary
+UNIQUE_DOCS=$(jq -r '[.[].doc] | unique | length' "$DRIFT_FILE" 2>/dev/null || echo "?")
+UNIQUE_SOURCES=$(jq -r '[.[].source] | unique | length' "$DRIFT_FILE" 2>/dev/null || echo "?")
+DOC_LIST=$(jq -r '[.[].doc] | unique | join(", ")' "$DRIFT_FILE" 2>/dev/null || echo "")
+
+cat <<RESP
+{
+  "hookSpecificOutput": {
+    "hookEventName": "Stop",
+    "systemMessage": "doc-sentinel: ${WARNING_COUNT} drift warning(s) accumulated during this session — ${UNIQUE_SOURCES} source file(s) changed that are referenced in ${UNIQUE_DOCS} doc(s): ${DOC_LIST}. Run /doc-sentinel:resolve to review each warning and fix affected documentation, or dismiss false positives."
+  }
+}
+RESP

--- a/plugins/doc-sentinel/hooks/stop-drift-report.sh
+++ b/plugins/doc-sentinel/hooks/stop-drift-report.sh
@@ -1,52 +1,122 @@
 #!/usr/bin/env bash
 # doc-sentinel: Stop hook
-# Checks for accumulated drift warnings and prompts resolution.
-# Exits cleanly on all errors.
+#
+# Blocks the model from stopping when drift warnings are accumulated and
+# instructs it to dispatch the drift-resolver subagent. A session-id marker
+# ensures we block at most once per session, so a subagent that can't fully
+# clear the drift file can't trap the model in an infinite loop.
+#
+# Why `decision: block` and not `systemMessage`:
+#   Stop-hook systemMessage is displayed to the user in the UI but is NOT
+#   auto-injected into the model's next-turn context, so it can't actually
+#   trigger autonomous behavior. `decision: "block"` with a `reason` is the
+#   only mechanism that forces the model to respond to the hook.
+#
+# Exits cleanly on all errors — never blocks on plumbing failures.
 
 set -euo pipefail
 
-DRIFT_FILE=".doc-sentinel-drift.json"
+# ─── Resolve project root ────────────────────────────────────────────────────
+# Hooks can run from any subdirectory of the project. Always prefer
+# $CLAUDE_PROJECT_DIR (exported by Claude Code) with a git fallback.
+PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || true)}"
+if [ -z "$PROJECT_ROOT" ]; then
+  exit 0
+fi
+
+DRIFT_FILE="$PROJECT_ROOT/.doc-sentinel-drift.json"
+MARKER_FILE="$PROJECT_ROOT/.doc-sentinel-last-session"
 
 # No drift file — nothing to do
 if [ ! -f "$DRIFT_FILE" ]; then
   exit 0
 fi
 
-# Check for jq
-if ! command -v jq &>/dev/null; then
-  # Fallback: count lines
+# ─── Read session id from stdin ──────────────────────────────────────────────
+# Claude Code passes a JSON envelope that includes session_id on Stop. We use
+# it to block at most once per session. If jq or session_id is missing we
+# still fire once (better a spurious block than silent drift).
+INPUT=$(cat || true)
+SESSION_ID=""
+if command -v jq &>/dev/null && [ -n "$INPUT" ]; then
+  SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
+fi
+
+# If we've already blocked for this session, don't block again — the agent is
+# presumably already working on it (or has given up on unresolvable entries).
+if [ -n "$SESSION_ID" ] && [ -f "$MARKER_FILE" ]; then
+  LAST_SESSION=$(cat "$MARKER_FILE" 2>/dev/null || true)
+  if [ "$LAST_SESSION" = "$SESSION_ID" ]; then
+    exit 0
+  fi
+fi
+
+# ─── Build the directive reason ──────────────────────────────────────────────
+build_reason() {
+  local count="$1"
+  local detail="$2"
+  cat <<PROMPT
+doc-sentinel: ${count} documentation drift warning(s) accumulated in .doc-sentinel-drift.json${detail}.
+
+Before stopping, dispatch the drift-resolver subagent to process them. Use the Agent tool with subagent_type: "doc-sentinel:drift-resolver" and include these instructions in the prompt:
+
+  1. Read .doc-sentinel-drift.json in the project root.
+  2. For each warning, judge whether it's real drift (the doc section that
+     references the changed source is now stale) or a false positive
+     (basename match with no actual content drift).
+  3. Update affected docs to match current source. Leave false positives alone.
+  4. Rewrite .doc-sentinel-drift.json as an empty array ([]) or keep only
+     entries you couldn't confidently resolve.
+  5. Commit any doc changes with a 'docs:' prefix — the post-commit hook
+     skips 'docs:' commits to prevent a feedback loop.
+
+After the subagent reports back, you may stop. This hook will block at most
+once per session, so if the subagent can't fully clear the file you won't be
+trapped in a loop.
+PROMPT
+}
+
+emit_block() {
+  # Claude Code's Stop hook accepts two mechanisms to prevent the model from
+  # stopping and feed back a directive:
+  #
+  #   1. JSON on stdout: `{"decision":"block","reason":"..."}`
+  #   2. Exit code 2 with the reason on stderr
+  #
+  # Empirically, the JSON mechanism is not honored in all Claude Code
+  # versions — the payload parses fine but the model still stops. Exit code 2
+  # with stderr is the older universal contract and reliably blocks.
+  local reason="$1"
+  printf '%s\n' "$reason" >&2
+  exit 2
+}
+
+# ─── Main ────────────────────────────────────────────────────────────────────
+if command -v jq &>/dev/null; then
+  WARNING_COUNT=$(jq 'length' "$DRIFT_FILE" 2>/dev/null || echo "0")
+  if [ "$WARNING_COUNT" -eq 0 ] || [ "$WARNING_COUNT" = "null" ]; then
+    exit 0
+  fi
+
+  UNIQUE_DOCS=$(jq -r '[.[].doc] | unique | length' "$DRIFT_FILE" 2>/dev/null || echo "?")
+  UNIQUE_SOURCES=$(jq -r '[.[].source] | unique | length' "$DRIFT_FILE" 2>/dev/null || echo "?")
+  DOC_LIST=$(jq -r '[.[].doc] | unique | join(", ")' "$DRIFT_FILE" 2>/dev/null || echo "")
+  DETAIL=" — ${UNIQUE_SOURCES} source file(s) changed that are referenced in ${UNIQUE_DOCS} doc(s): ${DOC_LIST}"
+else
   WARNING_COUNT=$(wc -l < "$DRIFT_FILE" | tr -d ' ')
   if [ "$WARNING_COUNT" -eq 0 ]; then
     exit 0
   fi
-
-  cat <<RESP
-{
-  "hookSpecificOutput": {
-    "hookEventName": "Stop",
-    "systemMessage": "doc-sentinel: ${WARNING_COUNT} documentation drift warning(s) detected during this session. Run /doc-sentinel:resolve to review and fix affected docs, or /doc-sentinel:scan for a full drift report."
-  }
-}
-RESP
-  exit 0
+  DETAIL=""
 fi
 
-# Parse with jq
-WARNING_COUNT=$(jq 'length' "$DRIFT_FILE" 2>/dev/null || echo "0")
-if [ "$WARNING_COUNT" -eq 0 ] || [ "$WARNING_COUNT" = "null" ]; then
-  exit 0
+REASON=$(build_reason "$WARNING_COUNT" "$DETAIL")
+
+# Record the marker BEFORE emit_block — that function calls `exit 2` so
+# nothing after it runs. Best-effort: a failed write just means we might
+# block twice for the same session, which is annoying but not looping.
+if [ -n "$SESSION_ID" ]; then
+  printf '%s' "$SESSION_ID" > "$MARKER_FILE" 2>/dev/null || true
 fi
 
-# Build summary
-UNIQUE_DOCS=$(jq -r '[.[].doc] | unique | length' "$DRIFT_FILE" 2>/dev/null || echo "?")
-UNIQUE_SOURCES=$(jq -r '[.[].source] | unique | length' "$DRIFT_FILE" 2>/dev/null || echo "?")
-DOC_LIST=$(jq -r '[.[].doc] | unique | join(", ")' "$DRIFT_FILE" 2>/dev/null || echo "")
-
-cat <<RESP
-{
-  "hookSpecificOutput": {
-    "hookEventName": "Stop",
-    "systemMessage": "doc-sentinel: ${WARNING_COUNT} drift warning(s) accumulated during this session — ${UNIQUE_SOURCES} source file(s) changed that are referenced in ${UNIQUE_DOCS} doc(s): ${DOC_LIST}. Run /doc-sentinel:resolve to review each warning and fix affected documentation, or dismiss false positives."
-  }
-}
-RESP
+emit_block "$REASON"

--- a/plugins/doc-sentinel/rules/doc-references.md
+++ b/plugins/doc-sentinel/rules/doc-references.md
@@ -1,0 +1,21 @@
+---
+globs: "*.md"
+---
+
+# Documentation Reference Hygiene
+
+When writing or editing documentation files:
+
+1. **Use relative paths** — reference source files with paths relative to the repo root (e.g., `src/routes/auth.ts`, not `/Users/me/project/src/routes/auth.ts`). Relative paths are detectable by drift scanning.
+
+2. **Quote file paths in backticks** — wrap paths in backticks so automated tools can extract them: `src/routes/auth.ts` not src/routes/auth.ts.
+
+3. **Keep path references specific** — reference `src/routes/auth.ts` not just `src/routes/`. Specific paths enable precise drift detection when files change.
+
+4. **Document ports with their source** — when mentioning a port, note where it is configured: "Dashboard runs on port 4000 (configured in `compose.yml`)". This makes drift traceable.
+
+5. **Document env vars with their location** — when referencing environment variables, note where they are defined: "`DATABASE_URL` (set in `.env`)".
+
+6. **Update docs in the same commit as code changes** — when renaming files, changing ports, or modifying env vars, update any documentation that references them in the same commit. This prevents drift from accumulating.
+
+7. **Use conventional commit prefixes for doc changes** — prefix documentation-only commits with `docs:` to prevent drift detection hooks from re-triggering.

--- a/plugins/doc-sentinel/skills/resolve/SKILL.md
+++ b/plugins/doc-sentinel/skills/resolve/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: resolve
+description: Review pending drift warnings and fix affected documentation or dismiss false positives
+disable-model-invocation: true
+allowed-tools: Read, Bash, Glob, Grep, Write, Edit, Agent
+---
+
+# doc-sentinel:resolve
+
+Process accumulated drift warnings from `.doc-sentinel-drift.json`. For each warning, verify whether the doc actually drifted, fix it if so, or dismiss if it is a false positive.
+
+## Phase 1: Load Drift Queue
+
+```bash
+cat .doc-sentinel-drift.json 2>/dev/null || echo "No drift warnings pending"
+```
+
+If the file is empty or missing, report "No drift warnings to resolve" and exit.
+
+## Phase 2: Deduplicate and Group
+
+Group warnings by doc file. Multiple source changes may affect the same doc — process them together for coherent updates.
+
+Example grouping:
+
+```
+ARCHITECTURE.md
+  - src/routes/auth.ts changed (commit abc123)
+  - src/routes/users.ts changed (commit def456)
+
+docs/api.md
+  - src/controllers/payments.ts changed (commit abc123)
+```
+
+Present the grouped summary and total count before proceeding.
+
+## Phase 3: Triage Each Group
+
+For each doc file with drift warnings:
+
+### 3a: Read Current State
+
+Read the doc file and the changed source files to understand what actually changed.
+
+### 3b: Classify the Drift
+
+Determine what kind of drift occurred:
+
+| Classification | Description | Action |
+|---------------|-------------|--------|
+| **Path moved** | Source file was renamed or moved | Update path references in doc |
+| **API changed** | Function signatures, endpoints, or interfaces changed | Update API documentation |
+| **Config changed** | Env vars, ports, or settings changed | Update config references |
+| **Structure changed** | Directories added/removed, module reorganized | Update codemap/architecture sections |
+| **Behavioral change** | Logic changed but interface stayed the same | Update descriptions if they mention specific behavior |
+| **False positive** | Doc references the file but the relevant content did not change | Dismiss |
+
+### 3c: Apply Fix or Dismiss
+
+**For real drift:**
+- Read the doc section that references the changed code
+- Read the new state of the source code
+- Update the doc to reflect the current reality
+- Keep the same writing style and level of detail as the surrounding content
+- If unsure about intent, add a `<!-- TODO: verify -->` comment rather than guessing
+
+**For false positives:**
+- Record as dismissed (remove from queue)
+- No changes needed
+
+## Phase 4: Commit Fixes
+
+After processing all groups:
+
+```bash
+# Stage only modified doc files
+git add <fixed-doc-files>
+git commit -m "docs: resolve documentation drift from recent changes
+
+Updated docs to reflect code changes detected by doc-sentinel:
+- <brief summary of fixes>"
+```
+
+Use the `docs:` commit prefix to prevent the post-commit hook from re-triggering on this commit.
+
+## Phase 5: Clear Drift Queue
+
+```bash
+# Remove the drift file — it is session-scoped
+rm -f .doc-sentinel-drift.json
+```
+
+## Phase 6: Report
+
+Print resolution summary:
+
+```
+doc-sentinel: resolved N drift warning(s)
+
+Fixed:
+  - ARCHITECTURE.md — updated 2 path references
+  - docs/api.md — updated endpoint documentation
+
+Dismissed (false positives):
+  - README.md — logo path unchanged despite src/ changes
+
+Remaining:
+  - None (all warnings resolved)
+```
+
+If any warnings could not be resolved automatically (require human judgment about intent), list them separately under "Needs Review" with specific questions.
+
+## Rules
+
+- Always read both the doc and the source before making changes
+- Preserve the existing writing style — match tone, detail level, and formatting
+- Never remove documentation sections wholesale — update them
+- Use `docs:` commit prefix to avoid hook feedback loops
+- If a doc file has >5 drift warnings from a single commit, consider whether the doc needs a broader rewrite rather than point fixes — dispatch a `drift-resolver` agent for complex cases
+- Delete `.doc-sentinel-drift.json` after processing, even if some warnings were dismissed
+- If doc-sync or inkwell is also installed, do not duplicate their work — sentinel fixes references and accuracy, not content generation

--- a/plugins/doc-sentinel/skills/scan/SKILL.md
+++ b/plugins/doc-sentinel/skills/scan/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: scan
+description: Full-codebase documentation drift scan — find every doc that references code reality incorrectly
+disable-model-invocation: true
+allowed-tools: Read, Bash, Glob, Grep
+---
+
+# doc-sentinel:scan
+
+Deep scan that cross-references all documentation against the current state of the codebase. Unlike the hook (which checks only files changed in a commit), this scans everything.
+
+This skill is **read-only** — it reports drift but does not modify files.
+
+## Phase 1: Load Configuration
+
+```bash
+cat .doc-sentinel.json 2>/dev/null || echo "No config — using defaults"
+```
+
+Defaults if no config:
+- `docs_root`: `docs`
+- `watch_files`: `AGENTS.md`, `ARCHITECTURE.md`, `README.md`, `CLAUDE.md`
+- `ignore_sources`: `*.test.*`, `*.spec.*`, `__tests__/**`
+
+## Phase 2: Discover Documentation
+
+Collect all doc files:
+
+```bash
+# docs/ directory
+find docs/ -name '*.md' -type f 2>/dev/null | sort
+
+# Top-level docs
+for f in AGENTS.md ARCHITECTURE.md CLAUDE.md README.md CHANGELOG.md; do
+  [ -f "$f" ] && echo "$f"
+done
+```
+
+Plus any `watch_files` from config.
+
+## Phase 3: Extract References
+
+For each doc file, extract references to source code:
+
+### 3a: File Path References
+
+Search for paths that look like source file references:
+
+```bash
+# Extract paths from backticks, links, and code blocks
+grep -oE '`[a-zA-Z0-9_./-]+\.(ts|js|py|rb|go|rs|java|tsx|jsx)`' "$doc_file"
+grep -oE '\b(src|lib|app|packages)/[a-zA-Z0-9_./-]+' "$doc_file"
+```
+
+### 3b: Command References
+
+Extract shell commands documented in the file:
+
+```bash
+# Find code blocks with shell commands
+grep -E '^\$|^pnpm |^npm |^yarn |^cargo |^go |^bundle |^python |^make ' "$doc_file"
+```
+
+### 3c: Port and URL References
+
+```bash
+grep -oE '(localhost|127\.0\.0\.1):[0-9]+' "$doc_file"
+grep -oE ':[0-9]{4,5}\b' "$doc_file"
+```
+
+### 3d: Environment Variable References
+
+```bash
+grep -oE '\$\{?[A-Z_][A-Z0-9_]*\}?' "$doc_file"
+grep -oE '`[A-Z_][A-Z0-9_]*`' "$doc_file"
+```
+
+## Phase 4: Validate References
+
+For each extracted reference, check if it still holds:
+
+### 4a: File Paths — Do They Exist?
+
+```bash
+# For each extracted path
+[ -f "$path" ] && echo "OK: $path" || echo "DRIFT: $path — file not found"
+```
+
+### 4b: Directory References — Do They Exist?
+
+```bash
+[ -d "$dir" ] && echo "OK: $dir" || echo "DRIFT: $dir — directory not found"
+```
+
+### 4c: Commands — Do They Parse?
+
+For package.json scripts:
+```bash
+# Check if documented npm/pnpm scripts exist
+jq -r '.scripts | keys[]' package.json 2>/dev/null
+```
+
+### 4d: Ports — Are They Consistent?
+
+Cross-reference ports mentioned in docs against:
+- `docker-compose.yml` / `compose.yml` port mappings
+- `.env` / `.env.example` port variables
+- Other doc files (detect conflicts between docs)
+
+### 4e: Env Vars — Are They Still Used?
+
+```bash
+# Check if documented env vars appear in source
+grep -r "$ENV_VAR" src/ lib/ app/ --include='*.ts' --include='*.js' --include='*.py' -l 2>/dev/null
+```
+
+### 4f: Symlink Integrity
+
+```bash
+# CLAUDE.md should symlink to AGENTS.md (if using agent-ready convention)
+[ -L "CLAUDE.md" ] && readlink CLAUDE.md || echo "Not a symlink"
+```
+
+## Phase 5: Freshness Analysis
+
+For each doc file, compare modification dates:
+
+```bash
+# When was the doc last modified?
+git log -1 --format="%ai" -- "$doc_file"
+
+# When were its referenced source files last modified?
+git log -1 --format="%ai" -- "$source_file"
+```
+
+**Freshness scoring:**
+
+| Score | Label | Criteria |
+|-------|-------|----------|
+| 0 | Fresh | Doc modified more recently than all referenced sources |
+| 1 | Current | Doc modified within 7 days of source changes |
+| 2 | Stale | Source changed 7-30 days after doc last updated |
+| 3 | Very Stale | Source changed >30 days after doc last updated |
+
+ADR files are exempt from freshness scoring — they are point-in-time records.
+
+## Phase 6: Generate Report
+
+Output a structured drift report organized by severity:
+
+```markdown
+# Documentation Drift Report
+Generated: YYYY-MM-DD HH:MM
+
+## Critical Drift (broken references)
+| Doc | Reference | Issue |
+|-----|-----------|-------|
+| ARCHITECTURE.md | `src/old-module/` | Directory not found |
+| AGENTS.md | `pnpm studio` | Script not in package.json |
+
+## Stale References (code changed, doc not updated)
+| Doc | Source File | Doc Last Updated | Source Last Updated | Freshness |
+|-----|------------|------------------|---------------------|-----------|
+| docs/api.md | src/routes/auth.ts | 2026-01-15 | 2026-04-01 | Very Stale |
+
+## Warnings
+| Doc | Issue |
+|-----|-------|
+| README.md | Port 3000 mentioned but compose.yml maps to 4000 |
+| AGENTS.md | Env var `OLD_VAR` not found in source |
+
+## Summary
+- X critical drift(s) — broken paths, missing files
+- Y stale reference(s) — code changed without doc updates
+- Z warning(s) — potential inconsistencies
+- N docs scanned, M references checked
+```
+
+## Rules
+
+- Never modify any files — this is a read-only scan
+- Report concrete evidence (file paths, line numbers, dates) not speculation
+- Skip vendored directories (node_modules, vendor, .git)
+- Treat CHANGELOG.md as append-only — only flag if it references non-existent versions/tags
+- ADRs are exempt from freshness checks
+- If a doc file is >500 lines, sample the first 200 and last 100 lines for references

--- a/plugins/doc-sentinel/skills/setup/SKILL.md
+++ b/plugins/doc-sentinel/skills/setup/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: setup
+description: Configure doc-sentinel drift detection for a project — detect docs root, watched files, and ignore patterns
+disable-model-invocation: true
+allowed-tools: Read, Bash, Glob, Grep, Write, Edit
+---
+
+# doc-sentinel:setup
+
+Interactive setup wizard that creates `.doc-sentinel.json` configuration.
+
+## Phase 1: Detect Project Layout
+
+Run these commands to understand the project:
+
+```bash
+# Project structure
+ls -la
+ls docs/ 2>/dev/null || echo "No docs/ directory"
+
+# Top-level doc files
+for f in AGENTS.md ARCHITECTURE.md CLAUDE.md README.md CHANGELOG.md; do
+  [ -f "$f" ] && echo "Found: $f"
+done
+
+# Check for existing config
+cat .doc-sentinel.json 2>/dev/null || echo "No existing config"
+
+# Check for companion plugins
+cat .doc-sync.json 2>/dev/null && echo "doc-sync detected"
+cat .inkwell.json 2>/dev/null && echo "inkwell detected"
+```
+
+## Phase 2: Discover Documentation Files
+
+```bash
+# Find all markdown docs
+find . -name '*.md' -not -path './node_modules/*' -not -path './.git/*' | head -50
+
+# Find source directories
+ls -d src/ lib/ app/ packages/ */ 2>/dev/null | head -20
+```
+
+## Phase 3: Configure
+
+Build `.doc-sentinel.json` interactively. Present detected values and ask for confirmation.
+
+### Configuration Schema
+
+```json
+{
+  "version": 1,
+  "docs_root": "docs",
+  "watch_files": [
+    "AGENTS.md",
+    "ARCHITECTURE.md",
+    "README.md"
+  ],
+  "ignore_sources": [
+    "*.test.*",
+    "*.spec.*",
+    "__tests__/**",
+    "*.d.ts"
+  ],
+  "ignore_docs": [],
+  "severity": {
+    "architecture": "high",
+    "agents_md": "high",
+    "api_reference": "medium",
+    "changelog": "low",
+    "readme": "medium"
+  }
+}
+```
+
+**Fields:**
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `version` | number | `1` | Config schema version |
+| `docs_root` | string | `"docs"` | Primary documentation directory |
+| `watch_files` | string[] | `["AGENTS.md", "ARCHITECTURE.md", "README.md"]` | Additional doc files outside docs_root to monitor |
+| `ignore_sources` | string[] | `["*.test.*", "*.spec.*", "__tests__/**", "*.d.ts"]` | Source file patterns to skip during drift detection |
+| `ignore_docs` | string[] | `[]` | Doc files to exclude from drift checks |
+| `severity` | object | see below | Drift severity by doc category |
+
+**Severity levels:** `high` (flag immediately), `medium` (flag at session end), `low` (include in scan reports only).
+
+Default severity:
+- `architecture` → high (ARCHITECTURE.md references are critical)
+- `agents_md` → high (AGENTS.md/CLAUDE.md references are critical)
+- `api_reference` → medium
+- `changelog` → low (changelogs are append-only, rarely drift)
+- `readme` → medium
+
+## Phase 4: Integration Check
+
+If doc-sync or inkwell config exists, note the relationship:
+
+> doc-sentinel complements doc-sync/inkwell. They write docs; sentinel catches when those docs drift from reality. No conflicts — they use separate queue files.
+
+## Phase 5: Write Configuration
+
+Write `.doc-sentinel.json` to the project root.
+
+Recommend adding to `.gitignore`:
+
+```
+.doc-sentinel-drift.json
+```
+
+The drift file is ephemeral (session-scoped warnings). The config file should be committed.
+
+## Phase 6: Confirm
+
+Print summary:
+
+```
+doc-sentinel configured:
+  Docs root:      docs/
+  Watched files:  AGENTS.md, ARCHITECTURE.md, README.md
+  Ignore sources: *.test.*, *.spec.*, __tests__/**, *.d.ts
+  Severity:       2 high, 2 medium, 1 low
+
+Hooks will detect drift on every commit. Run /doc-sentinel:scan for a baseline report.
+```


### PR DESCRIPTION
## Summary

Adds the `doc-sentinel` plugin — a proactive documentation drift detector — and consolidates the fix work required to make its Stop hook reliably auto-dispatch the `drift-resolver` subagent. Plugin version is **1.0.5**.

The first commit adds the plugin. The second commit collapses a multi-stage debugging session into a single fix covering bugs #1-#9 below.

## Bugs fixed in 1.0.1 → 1.0.5

1. **`systemMessage` placement** — Stop hook was emitting `systemMessage` nested under `hookSpecificOutput`; Stop hooks require it at the top level.
2. **`systemMessage` is informational only** — even at the top level, `systemMessage` renders as a UI status line and is **not** injected into the model's next-turn context. Empirically confirmed: the user had to paste the directive manually for Claude to act on it.
3. **`decision: "block"` JSON is unreliable** — 1.0.4 emitted `{"decision":"block","reason":"..."}`; the payload parses fine but the installed Claude Code version did not actually block the Stop. Per the docs both mechanisms should work; only the older one does in practice.
4. **Exit code 2 + stderr is the universal blocking contract** — `emit_block` now does `printf '%s\n' "$reason" >&2; exit 2`. This is the same mechanism PreToolUse hooks use. The session-marker write happens **before** `emit_block` since `exit 2` short-circuits.
5. **Session marker safety valve** — `.doc-sentinel-last-session` records the `session_id` from the hook stdin envelope and blocks at most once per session, so a drift-resolver run that can't fully clear the drift file can't trap Claude in a loop.
6. **Timeout units** — `hooks.json` `timeout` is seconds, not milliseconds. Corrected `5000` → `10` on both PostToolUse and Stop hooks.
7. **CWD handling** — hooks may run from any subdirectory of the project. Both scripts now resolve `$CLAUDE_PROJECT_DIR` with a `git rev-parse --show-toplevel` fallback and prefix `DRIFT_FILE` / `CONFIG_FILE` / `DOC_ROOT` with `$PROJECT_ROOT`.
8. **BSD sed delimiter bug** — `post-commit-drift.sh` glob→regex conversion used `/` as the sed delimiter with a `/` in the replacement, which fails on macOS sed. Switched to `#`.
9. **Directive wording** — Stop hook reason now includes a numbered 5-step plan telling Claude exactly how to invoke the drift-resolver and to commit its changes with a `docs:` prefix. The post-commit hook already skips `^docs(\(.+\))?:` commits, which closes the feedback loop.

## Why exit-2 (empirical evidence)

Per the Claude Code docs, Stop hooks expose two blocking mechanisms: JSON `{"decision":"block","reason":"..."}` on stdout, or exit code 2 with the reason on stderr. In the version of Claude Code currently installed, only the exit-2 mechanism actually prevents the model from stopping — the JSON payload is parsed without error but the Stop proceeds anyway. Exit-2 is the older universal contract and matches how PreToolUse hooks block tool calls, so the Stop hook now uses it exclusively.

## Test plan

- [x] Empty project (no drift file): `echo '{"session_id":"x"}' | CLAUDE_PROJECT_DIR=/tmp/fake bash plugins/doc-sentinel/hooks/stop-drift-report.sh` → exit 0, silent.
- [x] Populated drift file: exit 2, full numbered directive on stderr.
- [x] Second Stop-hook call with same `session_id`: exit 0 (marker honored, no re-block).
- [ ] End-to-end in a real repo: edit a source file referenced by a doc, commit with a non-`docs:` prefix, let the Stop hook fire, verify Claude dispatches the drift-resolver subagent autonomously.

## Plugin version

`1.0.5` in both `plugins/doc-sentinel/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`. No release tag — that's a manual step after merge.