### PR TITLE
feat: add dependabot-analyzer plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -64,6 +64,12 @@
       "source": "./plugins/doc-audit",
       "description": "Audit codebase documentation for accuracy, completeness, and freshness against actual code. Auto-fixes small discrepancies, reports structural changes. Companion to agent-ready.",
       "version": "1.0.0"
+    },
+    {
+      "name": "dependabot-analyzer",
+      "source": "./plugins/dependabot-analyzer",
+      "description": "Automated Dependabot PR triage — fans out parallel agents to assess risk, auto-merges safe patches, diagnoses CI failures, and creates issues for anything needing human attention.",
+      "version": "1.0.0"
     }
   ]
 }

--- a/plugins/dependabot-analyzer/.claude-plugin/plugin.json
+++ b/plugins/dependabot-analyzer/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "dependabot-analyzer",
+  "version": "1.0.0",
+  "description": "Automated Dependabot PR triage — fans out parallel agents to assess risk, auto-merges safe patches, diagnoses CI failures, and creates issues for anything needing human attention.",
+  "author": {
+    "name": "Damian Galarza",
+    "url": "https://www.damiangalarza.com"
+  },
+  "repository": "https://github.com/dgalarza/claude-code-workflows",
+  "license": "MIT",
+  "keywords": [
+    "dependabot",
+    "dependencies",
+    "security",
+    "automation",
+    "pr-review",
+    "ci",
+    "triage"
+  ]
+}

--- a/plugins/dependabot-analyzer/README.md
+++ b/plugins/dependabot-analyzer/README.md
@@ -1,0 +1,88 @@
+# Dependabot Analyzer
+
+Automated Dependabot PR triage for Claude Code. Fans out parallel agents to assess upgrade risk, auto-merges safe patches, diagnoses CI failures, and creates issues for PRs needing human attention.
+
+## What It Does
+
+1. **Discovers** all open Dependabot PRs in your repository (or multiple repos)
+2. **Analyzes** each PR in parallel — reviewing changelogs, assessing risk, checking dependency health
+3. **Auto-merges** safe updates (configurable thresholds)
+4. **Diagnoses CI failures** and attempts mechanical fixes when possible
+5. **Creates issues** in GitHub or Linear for updates that need human review
+
+## Installation
+
+```bash
+claude install-skill dgalarza/claude-code-workflows/plugins/dependabot-analyzer
+```
+
+## Usage
+
+Run the skill manually:
+
+```
+/dependabot-analyzer
+```
+
+Or set up a recurring schedule:
+
+```
+/schedule "Dependabot triage" --cron "0 9 * * 1" --prompt "/dependabot-analyzer"
+```
+
+## Configuration
+
+Create `.claude/dependabot-analyzer.json` in your project root:
+
+```json
+{
+  "auto_merge": {
+    "enabled": true,
+    "max_semver": "patch",
+    "require_ci_pass": true,
+    "exclude_packages": ["react", "next"]
+  },
+  "issue_tracker": "github",
+  "labels": ["dependabot-analyzer"],
+  "batch_size": 8,
+  "repos": ["."],
+  "risk_thresholds": {
+    "create_issue_above": 40,
+    "block_merge_above": 80
+  }
+}
+```
+
+All fields are optional — sensible defaults apply when omitted. See `skills/dependabot-analyzer/assets/config-schema.json` for the full schema with descriptions and defaults.
+
+### Linear Integration
+
+To use Linear as your issue tracker:
+
+```json
+{
+  "issue_tracker": "linear",
+  "linear_config": {
+    "team_id": "YOUR_TEAM_ID",
+    "project_id": "YOUR_PROJECT_ID",
+    "label_ids": ["label-1", "label-2"]
+  }
+}
+```
+
+Requires Linear MCP tools to be available. Falls back to GitHub Issues if not configured.
+
+## Risk Scoring
+
+Each PR is scored from 0--100 across seven weighted factors (semver bump, CI status, breaking changes, dependency health, dep location, diff size, transitive impact) with override rules for security fixes and major framework upgrades. See `skills/dependabot-analyzer/references/risk-model.md` for the full rubric and point values.
+
+## CI Failure Handling
+
+Failing CI is classified as upgrade-related (fixable), pre-existing (skipped), or infrastructure (skipped). Upgrade-related failures are auto-fixed when the change is mechanical and affects fewer than 5 files. See `skills/dependabot-analyzer/references/ci-diagnosis-guide.md` for the full diagnosis protocol.
+
+## Requirements
+
+- `gh` CLI authenticated with repo access
+- `python3` available on PATH (used by discovery and health-check scripts)
+- Dependabot enabled on the target repository
+- For Linear integration: Linear MCP tools configured

--- a/plugins/dependabot-analyzer/skills/dependabot-analyzer/SKILL.md
+++ b/plugins/dependabot-analyzer/skills/dependabot-analyzer/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: dependabot-analyzer
+description: Automated Dependabot PR triage — fans out parallel agents to assess upgrade risk, auto-merges safe patches, diagnoses CI failures, and creates issues for PRs needing human attention. Supports GitHub Issues and Linear for issue tracking.
+---
+
+# Dependabot PR Analyzer
+
+Analyze open Dependabot PRs across one or more repositories. Assess risk, auto-merge safe updates, diagnose CI failures, and create issues for anything requiring human review.
+
+Work through the following phases sequentially.
+
+---
+
+## Phase 1: Configuration & Discovery
+
+Execute directly — no sub-agents needed.
+
+### Step 1: Load Configuration
+
+Read `.claude/dependabot-analyzer.json` from the project root. If the file does not exist, use these defaults and inform the user:
+
+```json
+{
+  "auto_merge": {
+    "enabled": true,
+    "max_semver": "patch",
+    "require_ci_pass": true,
+    "exclude_packages": []
+  },
+  "issue_tracker": "github",
+  "labels": ["dependabot-analyzer"],
+  "batch_size": 8,
+  "repos": ["."],
+  "risk_thresholds": {
+    "create_issue_above": 40,
+    "block_merge_above": 80
+  }
+}
+```
+
+Validate the loaded config:
+- `batch_size` must be 1–10. Clamp and warn if out of range.
+- `risk_thresholds.create_issue_above` must be less than `block_merge_above`. Warn if inverted.
+- If `issue_tracker` is `"linear"`, verify `linear_config.team_id` is present. If missing, fall back to `"github"` with a warning.
+- Apply defaults for any missing fields — never fail on a partial config.
+
+See `assets/config-schema.json` for the full schema with descriptions and defaults.
+
+### Step 2: Discover Open PRs
+
+Run the discovery script for each repo in `repos`:
+
+```bash
+bash scripts/discover-prs.sh
+```
+
+For repos other than `"."`, pass the `--repo` flag:
+
+```bash
+bash scripts/discover-prs.sh --repo owner/repo
+```
+
+The script is located at `scripts/discover-prs.sh` relative to this skill's directory.
+
+After reviewing the output, format a **PR Discovery Summary**:
+
+```
+## PR Discovery Summary
+
+**Repository**: {repo}
+**Open Dependabot PRs**: {count}
+
+| PR | Dependency | Current → New | Bump | CI Status | Location | Days Open |
+|----|------------|---------------|------|-----------|----------|-----------|
+| #{n} | {name}  | {v1} → {v2}   | {type} | {status} | {loc}  | {days}    |
+```
+
+If zero PRs are found across all repos, report this to the user and stop. No further phases are needed.
+
+If the total PR count exceeds `batch_size`, process in batches — complete one batch of analysis before starting the next.
+
+---
+
+## Phase 2: Parallel PR Analysis
+
+Fan out one agent per PR for independent risk assessment. Before launching agents, read the risk scoring rubric from `references/risk-model.md` — include its full content in each agent's prompt.
+
+### Agent Launch
+
+Send a **single message with N Agent tool calls** (one per PR, up to `batch_size`). Each agent uses `subagent_type: "general-purpose"` with no worktree isolation (read-only analysis).
+
+For each PR, compose the agent prompt from these parts:
+
+**1. Role preamble:**
+```
+You are a dependency update risk assessor. Analyze a single Dependabot PR and produce a structured risk assessment.
+```
+
+**2. PR context** (from Phase 1 discovery):
+```
+## PR Context
+
+- PR: #{number}
+- Title: {title}
+- Repository: {repo}
+- Dependency: {dep_name}
+- Ecosystem: {ecosystem}
+- Current version: {current_version}
+- New version: {new_version}
+- Bump type: {bump_type}
+- CI status: {ci_status}
+- Dependency location: {prod|dev}
+- Lines changed: {total_lines}
+- Days open: {days_open}
+```
+
+**3. Evidence gathering instructions:**
+```
+## Evidence to Gather
+
+Run these commands to collect evidence for your assessment:
+
+1. Review the PR diff:
+   gh pr diff {number} [--repo owner/repo]
+
+2. Review the PR description and Dependabot's notes:
+   gh pr view {number} [--repo owner/repo]
+
+3. Check CI status in detail:
+   gh pr checks {number} [--repo owner/repo]
+
+4. If CI is failing, get the failure logs:
+   gh run view {run_id} --log-failed [--repo owner/repo]
+
+5. Check dependency health:
+   bash {skill_dir}/scripts/check-dep-health.sh {ecosystem} {package_name}
+```
+
+**4. Risk model** (full content of `references/risk-model.md`, inlined).
+
+**5. CI diagnosis instructions** (only include if CI status is `failing`):
+
+Include the full content of `references/ci-diagnosis-guide.md` and add:
+```
+Classify the CI failure into Category 1 (upgrade-related), Category 2 (pre-existing), or Category 3 (infrastructure). If Category 1 and the fix meets all criteria in the Fix Protocol, describe the exact changes needed.
+```
+
+**6. Output format:**
+```
+## Required Output
+
+Produce a structured assessment in exactly this format:
+
+### Assessment: PR #{number} — {dependency}
+
+**Risk Score**: {score}/100
+**Risk Band**: {Safe|Low|Medium|High|Critical}
+**Recommendation**: {auto-merge|create-issue|attempt-ci-fix|block}
+
+**Factor Breakdown**:
+| Factor | Points | Notes |
+|--------|--------|-------|
+| Semver bump | {n} | {details} |
+| CI status | {n} | {details} |
+| Breaking changes | {n} | {details} |
+| Dependency health | {n} | {rating} |
+| Dep location | {n} | {prod/dev} |
+| Diff size | {n} | {lines} lines |
+| Transitive impact | {n} | {count} deps |
+
+**Override rules applied**: {list any that applied, or "None"}
+
+**Changelog highlights**: {2-3 sentence summary of what changed}
+
+**CI diagnosis**: {diagnosis or "N/A — CI passing"}
+{If Category 1 fixable: describe the exact fix needed}
+
+**Evidence summary**: {key observations from the diff, health check, and PR description}
+```
+
+Wait for all agents to complete before proceeding to Phase 3.
+
+---
+
+## Phase 3: Execute Actions
+
+Process each PR's assessment and take the appropriate action based on the recommendation and config settings.
+
+### Auto-Merge (recommendation: `auto-merge`)
+
+Verify all conditions before merging:
+1. `auto_merge.enabled` is `true` in config
+2. Bump type is within `auto_merge.max_semver` (patch ≤ minor ≤ major)
+3. Package is not in `auto_merge.exclude_packages`
+4. CI is passing (if `auto_merge.require_ci_pass` is `true`)
+5. Risk score is at or below `risk_thresholds.block_merge_above`
+
+If all conditions pass:
+```bash
+gh pr merge {number} --squash [--repo owner/repo]
+```
+
+Note: use `--auto` instead of immediate merge when branch protection requires additional status checks that have not yet completed. The `--auto` flag queues the merge to execute once all branch protection requirements are met — it does not merge immediately.
+
+If the risk band is "Low" (21–40), include a note in the report that the PR was auto-merged but had a non-trivial risk score — this gives the user visibility into borderline merges.
+
+If any condition fails, downgrade to issue creation and note which condition blocked the merge.
+
+### CI Fix Attempt (recommendation: `attempt-ci-fix`)
+
+Only attempt when the Phase 2 agent classified the failure as Category 1 (upgrade-related) and the fix meets the Fix Protocol criteria.
+
+Launch a **single Agent** with `isolation: "worktree"` for each fix attempt. Include in the prompt:
+- The specific fix described in the Phase 2 assessment
+- Instructions to check out the Dependabot branch, apply the fix, run the failing tests, and push if passing
+- The full CI diagnosis guide from `references/ci-diagnosis-guide.md`
+
+Process CI fixes **sequentially** (not in parallel) to avoid branch conflicts between related dependency updates.
+
+If the fix succeeds, re-evaluate whether the PR now qualifies for auto-merge. If the fix fails, fall through to issue creation.
+
+### Issue Creation (recommendation: `create-issue` or `block`, or fallback from failed conditions)
+
+Before creating an issue, check for existing open issues from a previous run:
+
+```bash
+gh issue list --label "dependabot-analyzer" --search "PR #{number}" --state open [--repo owner/repo]
+```
+
+If a matching issue already exists, skip creation and note "existing issue found" in the report. This prevents duplicate issues when running on a schedule.
+
+Create an issue in the configured tracker using the template from `assets/github-issue-template.md`.
+
+**GitHub Issues**:
+```bash
+gh issue create --title "Review: {dependency} {current} → {new}" --body "{filled_template}" --label "{labels}" [--repo owner/repo]
+```
+
+**Linear** (when `issue_tracker` is `"linear"` and Linear MCP tools are available):
+Use `mcp__linear__create_issue()` with the configured `team_id`, `project_id`, and `label_ids`.
+
+Fill the template with:
+- PR number, title, dependency details, versions
+- Full risk factor breakdown from the Phase 2 assessment
+- Changelog summary
+- CI diagnosis (if applicable)
+- Concrete next steps based on the assessment
+
+---
+
+## Phase 4: Consolidated Report
+
+Read the report template from `assets/report-template.md` and fill it with data from all phases:
+
+- **Summary metrics**: total analyzed, auto-merged, CI fixes attempted/succeeded, issues created
+- **PR table**: one row per PR with risk score and action taken
+- **Detailed assessments**: full Phase 2 output for each PR
+- **Recommendations**: patterns observed, config tuning suggestions, follow-up actions
+
+Present the completed report to the user.
+
+---
+
+## Phase 5: Follow-up
+
+Offer two optional actions:
+
+1. **Save the report**: Write to `DEPENDABOT_ANALYSIS.md` in the project root. Ask the user before writing.
+
+2. **Set up recurring schedule**: Explain that this skill can run on a schedule using Claude Code's native scheduling. Suggest a cron expression based on the PR volume observed:
+   - 10+ open PRs: daily at 9am (`0 9 * * *`)
+   - 3–9 open PRs: twice weekly (`0 9 * * 1,4`)
+   - 1–2 open PRs: weekly Monday 9am (`0 9 * * 1`)
+
+   The user can set this up with the `/schedule` command — this skill does not manage its own scheduling.

--- a/plugins/dependabot-analyzer/skills/dependabot-analyzer/assets/config-schema.json
+++ b/plugins/dependabot-analyzer/skills/dependabot-analyzer/assets/config-schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Dependabot Analyzer Configuration",
+  "description": "Per-project configuration for the dependabot-analyzer plugin. Place at .claude/dependabot-analyzer.json in your project root.",
+  "type": "object",
+  "properties": {
+    "auto_merge": {
+      "type": "object",
+      "description": "Controls automatic merging of low-risk Dependabot PRs.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to auto-merge PRs that fall within the safe threshold."
+        },
+        "max_semver": {
+          "type": "string",
+          "enum": ["patch", "minor", "major"],
+          "default": "patch",
+          "description": "Maximum semver bump level eligible for auto-merge."
+        },
+        "require_ci_pass": {
+          "type": "boolean",
+          "default": true,
+          "description": "Require all CI checks to pass before auto-merging."
+        },
+        "exclude_packages": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Package names that should never be auto-merged, regardless of risk score."
+        }
+      },
+      "additionalProperties": false
+    },
+    "issue_tracker": {
+      "type": "string",
+      "enum": ["github", "linear"],
+      "default": "github",
+      "description": "Where to create issues for PRs requiring deeper review."
+    },
+    "linear_config": {
+      "type": "object",
+      "description": "Required when issue_tracker is 'linear'. Linear project configuration.",
+      "properties": {
+        "team_id": {
+          "type": "string",
+          "description": "Linear team identifier."
+        },
+        "project_id": {
+          "type": "string",
+          "description": "Linear project identifier."
+        },
+        "label_ids": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Linear label IDs to apply to created issues."
+        }
+      },
+      "required": ["team_id"],
+      "additionalProperties": false
+    },
+    "labels": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": ["dependabot-analyzer"],
+      "description": "Labels to apply to created GitHub issues."
+    },
+    "batch_size": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 10,
+      "default": 8,
+      "description": "Maximum number of parallel analysis agents to launch at once."
+    },
+    "repos": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": ["."],
+      "description": "Repositories to analyze. Use '.' for the current repo, or 'owner/repo' slugs for other repos."
+    },
+    "risk_thresholds": {
+      "type": "object",
+      "description": "Risk score thresholds that control when issues are created and merges are blocked.",
+      "properties": {
+        "create_issue_above": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100,
+          "default": 40,
+          "description": "Create an issue for PRs with a risk score above this value."
+        },
+        "block_merge_above": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100,
+          "default": 80,
+          "description": "Never auto-merge PRs with a risk score above this value."
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/plugins/dependabot-analyzer/skills/dependabot-analyzer/assets/github-issue-template.md
+++ b/plugins/dependabot-analyzer/skills/dependabot-analyzer/assets/github-issue-template.md
@@ -1,0 +1,40 @@
+## Dependabot Update Requires Review
+
+**PR**: #{pr_number} — {pr_title}
+**Dependency**: `{dependency_name}` {current_version} → {new_version}
+**Bump type**: {bump_type}
+**Risk score**: {risk_score}/100 ({risk_band})
+
+---
+
+### Why This Needs Review
+
+{reason}
+
+### Risk Factor Breakdown
+
+| Factor | Points | Notes |
+|--------|--------|-------|
+| Semver bump | {n} | {bump_type} |
+| CI status | {n} | {status} |
+| Breaking changes | {n} | {notes} |
+| Dependency health | {n} | {rating} |
+| Dep location | {n} | {location} |
+| Diff size | {n} | {lines} lines changed |
+| Transitive impact | {n} | {count} transitive deps affected |
+
+### Changelog Summary
+
+{changelog_summary}
+
+### CI Status
+
+{ci_details}
+
+### Suggested Next Steps
+
+{next_steps}
+
+---
+
+*Created by [dependabot-analyzer](https://github.com/dgalarza/claude-code-workflows)*

--- a/plugins/dependabot-analyzer/skills/dependabot-analyzer/assets/report-template.md
+++ b/plugins/dependabot-analyzer/skills/dependabot-analyzer/assets/report-template.md
@@ -1,0 +1,40 @@
+# Dependabot Analysis Report
+
+**Repository**: {repo}
+**Date**: {date}
+**PRs Analyzed**: {total_prs}
+
+---
+
+## Summary
+
+| Metric | Count |
+|--------|-------|
+| Total PRs analyzed | {total_prs} |
+| Auto-merged | {auto_merged} |
+| CI fixes attempted | {ci_fixes_attempted} |
+| CI fixes succeeded | {ci_fixes_succeeded} |
+| Issues created | {issues_created} |
+| Skipped (below threshold) | {skipped} |
+
+---
+
+## PR Results
+
+| PR | Dependency | Bump | Risk Score | Band | Action Taken |
+|----|------------|------|------------|------|--------------|
+{pr_rows}
+
+---
+
+## Detailed Assessments
+
+<!-- Paste each PR's Phase 2 assessment output here. -->
+
+{detailed_assessments}
+
+---
+
+## Recommendations
+
+{recommendations}

--- a/plugins/dependabot-analyzer/skills/dependabot-analyzer/references/ci-diagnosis-guide.md
+++ b/plugins/dependabot-analyzer/skills/dependabot-analyzer/references/ci-diagnosis-guide.md
@@ -1,0 +1,67 @@
+# CI Failure Diagnosis Guide
+
+When a Dependabot PR has failing CI checks, classify the failure into one of three categories before deciding whether to attempt a fix.
+
+## Failure Categories
+
+### Category 1: Upgrade-Related (Fixable)
+
+The failure is directly caused by the dependency update. Symptoms:
+
+- Import path changed (e.g., `require('pkg/old-path')` → `require('pkg/new-path')`)
+- Method or function renamed or removed
+- Type signature changed (new required parameter, changed return type)
+- Configuration format changed (e.g., config key renamed)
+- Deprecated API removed in the new version
+
+**Action**: Attempt a fix if the change is mechanical — fewer than 5 files affected, and the migration is documented in the package's changelog or upgrade guide.
+
+### Category 2: Pre-Existing (Do Not Fix)
+
+The same test fails on the main branch. The failure is unrelated to the dependency update.
+
+**How to verify**: Check if the failing test also fails on `main` by reviewing recent CI runs on the default branch, or by looking at `gh pr checks` output for the base branch.
+
+**Action**: Do not attempt a fix. Note in the assessment that CI failure is pre-existing and unrelated to this update.
+
+### Category 3: Infrastructure (Do Not Fix)
+
+The failure is caused by CI infrastructure, not code. Symptoms:
+
+- Timeout errors
+- Network connectivity failures (registry unreachable, DNS resolution)
+- Runner provisioning failures
+- Rate limiting from external services
+- Disk space or memory exhaustion
+- Docker pull failures
+
+**Action**: Do not attempt a fix. Note in the assessment that CI failure appears to be infrastructure-related. Suggest re-running the workflow.
+
+## Fix Protocol
+
+Only attempt fixes for Category 1 failures that meet ALL of these criteria:
+
+1. **Mechanical change** — The fix is a straightforward substitution (import path, method name, type annotation, config key). No business logic changes.
+2. **Small scope** — Fewer than 5 files need modification.
+3. **Documented** — The package changelog, release notes, or migration guide describes the required change.
+4. **No architectural impact** — The fix does not require restructuring code, changing patterns, or updating multiple abstraction layers.
+
+### Fix Steps
+
+1. Read the failing CI logs (`gh run view --log-failed`)
+2. Identify the specific error (compile error, test assertion, type error)
+3. Cross-reference with the package changelog for migration instructions
+4. Make the minimal change to resolve the error
+5. Run the failing test locally if possible to verify
+6. Commit with message: `fix: update usage for {package}@{version}`
+7. Push to the Dependabot branch
+
+### When to Abort
+
+Stop and fall through to issue creation if:
+
+- The fix requires changing more than 5 files
+- The migration guide describes a multi-step process
+- The error is in generated code or vendored dependencies
+- You are uncertain whether the fix preserves existing behavior
+- Multiple unrelated tests are failing

--- a/plugins/dependabot-analyzer/skills/dependabot-analyzer/references/risk-model.md
+++ b/plugins/dependabot-analyzer/skills/dependabot-analyzer/references/risk-model.md
@@ -1,0 +1,88 @@
+# Risk Scoring Model
+
+Score each Dependabot PR from 0–100 using the factors below. Add the points from each factor to produce a total risk score.
+
+## Factors
+
+### 1. Semver Bump (0–30)
+
+| Bump Type | Points |
+|-----------|--------|
+| Patch     | 0      |
+| Minor     | 10     |
+| Major     | 30     |
+
+### 2. CI Status (0–25)
+
+| Status  | Points |
+|---------|--------|
+| Passing | 0      |
+| Pending | 10     |
+| Failing | 25     |
+
+### 3. Breaking Changes (0–20)
+
+Assess from the changelog, release notes, and diff.
+
+| Finding                                  | Points |
+|------------------------------------------|--------|
+| No breaking changes                      | 0      |
+| Breaking changes with documented migration | 10   |
+| Breaking changes without migration guide | 20     |
+
+### 4. Dependency Health (0–10)
+
+Use output from `check-dep-health.sh`.
+
+| Rating    | Points |
+|-----------|--------|
+| Good      | 0      |
+| Fair      | 5      |
+| Stale     | 7      |
+| Abandoned or has known vulnerabilities | 10 |
+
+### 5. Dependency Location (0–5)
+
+| Location          | Points |
+|-------------------|--------|
+| Dev dependency    | 0      |
+| Production dependency | 5  |
+
+### 6. Diff Size (0–5)
+
+| Lines Changed | Points |
+|---------------|--------|
+| < 50          | 0      |
+| 50–199        | 2      |
+| 200–499       | 3      |
+| 500+          | 5      |
+
+### 7. Transitive Impact (0–5)
+
+Estimate from lockfile changes — how many transitive dependencies are affected.
+
+| Transitive Deps Changed | Points |
+|--------------------------|--------|
+| 0–2                      | 0      |
+| 3–5                      | 2      |
+| 6+                       | 5      |
+
+## Override Rules
+
+Apply these after computing the base score:
+
+- **Security fix**: If the update addresses a known vulnerability in the current version, cap the score at 20 regardless of other factors. Add a note: "Security fix — fast-track recommended."
+- **Major framework upgrade**: If the dependency is a core framework (e.g., React, Rails, Django, Next.js, Express), add 10 points to the base score. These have outsized blast radius.
+- **Stale PR**: If the PR has been open for more than 30 days, add a staleness note (but do not change the score). Stale PRs may have merge conflicts or outdated lockfiles.
+
+After applying all overrides, **clamp the final score to 0–100**.
+
+## Risk Bands
+
+| Score | Band     | Recommended Action |
+|-------|----------|--------------------|
+| 0–20  | Safe     | Auto-merge (if config allows) |
+| 21–40 | Low      | Auto-merge with note |
+| 41–60 | Medium   | Create issue for review |
+| 61–80 | High     | Create issue, flag for prompt attention |
+| 81–100| Critical | Create issue, block merge, escalate |

--- a/plugins/dependabot-analyzer/skills/dependabot-analyzer/scripts/check-dep-health.sh
+++ b/plugins/dependabot-analyzer/skills/dependabot-analyzer/scripts/check-dep-health.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# check-dep-health.sh — Query package registry APIs for dependency health metrics.
+#
+# Usage:
+#   bash check-dep-health.sh <ecosystem> <package-name>
+#
+# Supported ecosystems: npm, pip, bundler (rubygems), cargo, gomod
+# Output: Structured text with health rating and supporting data.
+
+set -euo pipefail
+
+ECOSYSTEM="${1:-}"
+PACKAGE="${2:-}"
+
+if [[ -z "$ECOSYSTEM" || -z "$PACKAGE" ]]; then
+  echo "Usage: check-dep-health.sh <ecosystem> <package-name>"
+  echo "Ecosystems: npm, pip, bundler, cargo, gomod"
+  exit 1
+fi
+
+echo "=== DEPENDENCY HEALTH CHECK ==="
+echo "Package: $PACKAGE"
+echo "Ecosystem: $ECOSYSTEM"
+echo ""
+
+fetch_npm() {
+  local data
+  data=$(curl -sf "https://registry.npmjs.org/$PACKAGE" 2>/dev/null) || {
+    echo "Registry: npm"
+    echo "Status: NOT FOUND"
+    echo "Health: unknown"
+    return
+  }
+
+  local latest modified weekly_downloads
+  latest=$(echo "$data" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('dist-tags',{}).get('latest','unknown'))" 2>/dev/null || echo "unknown")
+  modified=$(echo "$data" | python3 -c "import sys,json; print(json.load(sys.stdin).get('time',{}).get('modified','unknown'))" 2>/dev/null || echo "unknown")
+
+  # Get download count
+  weekly_downloads=$(curl -sf "https://api.npmjs.org/downloads/point/last-week/$PACKAGE" 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('downloads',0))" 2>/dev/null || echo "0")
+
+  echo "Registry: npm"
+  echo "Latest version: $latest"
+  echo "Last modified: $modified"
+  echo "Weekly downloads: $weekly_downloads"
+}
+
+fetch_pip() {
+  local data
+  data=$(curl -sf "https://pypi.org/pypi/$PACKAGE/json" 2>/dev/null) || {
+    echo "Registry: pypi"
+    echo "Status: NOT FOUND"
+    echo "Health: unknown"
+    return
+  }
+
+  local version upload_time
+  version=$(echo "$data" | python3 -c "import sys,json; print(json.load(sys.stdin)['info']['version'])" 2>/dev/null || echo "unknown")
+  upload_time=$(echo "$data" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+v=d['info']['version']
+urls=d.get('urls',[])
+if urls:
+    print(urls[0].get('upload_time','unknown'))
+else:
+    releases=d.get('releases',{}).get(v,[])
+    print(releases[0].get('upload_time','unknown') if releases else 'unknown')
+" 2>/dev/null || echo "unknown")
+
+  echo "Registry: pypi"
+  echo "Latest version: $version"
+  echo "Last release: $upload_time"
+}
+
+fetch_bundler() {
+  local data
+  data=$(curl -sf "https://rubygems.org/api/v1/gems/$PACKAGE.json" 2>/dev/null) || {
+    echo "Registry: rubygems"
+    echo "Status: NOT FOUND"
+    echo "Health: unknown"
+    return
+  }
+
+  local version downloads
+  version=$(echo "$data" | python3 -c "import sys,json; print(json.load(sys.stdin).get('version','unknown'))" 2>/dev/null || echo "unknown")
+  downloads=$(echo "$data" | python3 -c "import sys,json; print(json.load(sys.stdin).get('downloads',0))" 2>/dev/null || echo "0")
+
+  echo "Registry: rubygems"
+  echo "Latest version: $version"
+  echo "Total downloads: $downloads"
+}
+
+fetch_cargo() {
+  local data
+  data=$(curl -sf "https://crates.io/api/v1/crates/$PACKAGE" 2>/dev/null) || {
+    echo "Registry: crates.io"
+    echo "Status: NOT FOUND"
+    echo "Health: unknown"
+    return
+  }
+
+  local version downloads updated
+  version=$(echo "$data" | python3 -c "import sys,json; print(json.load(sys.stdin)['crate']['newest_version'])" 2>/dev/null || echo "unknown")
+  downloads=$(echo "$data" | python3 -c "import sys,json; print(json.load(sys.stdin)['crate']['downloads'])" 2>/dev/null || echo "0")
+  updated=$(echo "$data" | python3 -c "import sys,json; print(json.load(sys.stdin)['crate']['updated_at'])" 2>/dev/null || echo "unknown")
+
+  echo "Registry: crates.io"
+  echo "Latest version: $version"
+  echo "Total downloads: $downloads"
+  echo "Last updated: $updated"
+}
+
+fetch_gomod() {
+  echo "Registry: pkg.go.dev"
+  local data
+  data=$(curl -sf "https://proxy.golang.org/$PACKAGE/@latest" 2>/dev/null) || {
+    echo "Status: NOT FOUND"
+    echo "Health: unknown"
+    return
+  }
+
+  local version time_stamp
+  version=$(echo "$data" | python3 -c "import sys,json; print(json.load(sys.stdin).get('Version','unknown'))" 2>/dev/null || echo "unknown")
+  time_stamp=$(echo "$data" | python3 -c "import sys,json; print(json.load(sys.stdin).get('Time','unknown'))" 2>/dev/null || echo "unknown")
+
+  echo "Latest version: $version"
+  echo "Release time: $time_stamp"
+}
+
+# Route to the appropriate registry
+case "$ECOSYSTEM" in
+  npm|npm_and_yarn)     fetch_npm ;;
+  pip|pip3|pipenv)      fetch_pip ;;
+  bundler|rubygems)     fetch_bundler ;;
+  cargo)                fetch_cargo ;;
+  gomod|go_modules)     fetch_gomod ;;
+  *)
+    echo "Registry: $ECOSYSTEM (unsupported)"
+    echo "Health: unknown"
+    echo "Note: Ecosystem '$ECOSYSTEM' is not yet supported. Manual review recommended."
+    ;;
+esac
+
+# Check for known vulnerabilities via GitHub Advisory Database
+echo ""
+echo "=== VULNERABILITY CHECK ==="
+VULN_DATA=$(gh api graphql -f query="
+{
+  securityVulnerabilities(first: 5, ecosystem: $(echo "$ECOSYSTEM" | python3 -c "
+import sys
+eco = sys.stdin.read().strip()
+mapping = {
+    'npm': 'NPM', 'npm_and_yarn': 'NPM',
+    'pip': 'PIP', 'pip3': 'PIP', 'pipenv': 'PIP',
+    'bundler': 'RUBYGEMS', 'rubygems': 'RUBYGEMS',
+    'cargo': 'RUST',
+    'gomod': 'GO', 'go_modules': 'GO',
+    'nuget': 'NUGET',
+    'maven': 'MAVEN'
+}
+print(mapping.get(eco, 'NPM'))
+"), package: \"$PACKAGE\") {
+    nodes {
+      advisory { summary severity publishedAt }
+      vulnerableVersionRange
+    }
+  }
+}" 2>/dev/null) || VULN_DATA=""
+
+if [[ -n "$VULN_DATA" ]]; then
+  VULN_COUNT=$(echo "$VULN_DATA" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+nodes=d.get('data',{}).get('securityVulnerabilities',{}).get('nodes',[])
+print(len(nodes))
+for n in nodes:
+    adv = n.get('advisory',{})
+    print(f\"  - {adv.get('severity','UNKNOWN')}: {adv.get('summary','No summary')} (range: {n.get('vulnerableVersionRange','unknown')})\")
+" 2>/dev/null || echo "0")
+  echo "Known vulnerabilities: $VULN_COUNT"
+else
+  echo "Known vulnerabilities: Unable to check (gh API unavailable)"
+fi

--- a/plugins/dependabot-analyzer/skills/dependabot-analyzer/scripts/discover-prs.sh
+++ b/plugins/dependabot-analyzer/skills/dependabot-analyzer/scripts/discover-prs.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# discover-prs.sh — Find open Dependabot PRs and extract metadata.
+#
+# Usage:
+#   bash discover-prs.sh [--repo owner/repo]
+#
+# Output: Structured text blocks, one per PR, separated by "---".
+
+set -euo pipefail
+
+REPO_ARGS=()
+if [[ "${1:-}" == "--repo" && -n "${2:-}" ]]; then
+  REPO_ARGS=(--repo "$2")
+fi
+
+# Fetch open Dependabot PRs
+PR_JSON=$(gh pr list \
+  "${REPO_ARGS[@]}" \
+  --author "app/dependabot" \
+  --state open \
+  --json number,title,headRefName,additions,deletions,createdAt,statusCheckRollup \
+  --limit 100 2>/dev/null)
+
+PR_COUNT=$(echo "$PR_JSON" | python3 -c "import sys,json; print(len(json.load(sys.stdin)))" 2>/dev/null || echo "0")
+
+echo "=== DEPENDABOT PR DISCOVERY ==="
+echo "Timestamp: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+echo "Total open PRs: $PR_COUNT"
+echo ""
+
+if [[ "$PR_COUNT" == "0" ]]; then
+  echo "No open Dependabot PRs found."
+  exit 0
+fi
+
+# Process each PR
+echo "$PR_JSON" | python3 -c "
+import sys, json, re
+from datetime import datetime, timezone
+
+prs = json.load(sys.stdin)
+
+for pr in prs:
+    number = pr['number']
+    title = pr['title']
+    branch = pr['headRefName']
+    additions = pr['additions']
+    deletions = pr['deletions']
+    created = pr['createdAt']
+
+    # Parse branch: dependabot/{ecosystem}/{dep-name}-{version}
+    # or: dependabot/{ecosystem}/{scope}/{dep-name}-{version}
+    branch_match = re.match(r'dependabot/([^/]+)/(.+)', branch)
+    ecosystem = branch_match.group(1) if branch_match else 'unknown'
+    dep_slug = branch_match.group(2) if branch_match else branch
+
+    # Extract version from title patterns like:
+    #   'Bump foo from 1.0.0 to 2.0.0'
+    #   'Update foo requirement from ~> 1.0 to ~> 2.0'
+    version_match = re.search(r'from\s+[~>=<]*\s*([\d][^\s]*)\s+to\s+[~>=<]*\s*([\d][^\s]*)', title)
+    current_version = version_match.group(1) if version_match else 'unknown'
+    new_version = version_match.group(2) if version_match else 'unknown'
+
+    # Determine semver bump type
+    bump_type = 'unknown'
+    if current_version != 'unknown' and new_version != 'unknown':
+        try:
+            cur_parts = current_version.split('.')
+            new_parts = new_version.split('.')
+            cur_major = int(re.match(r'\d+', cur_parts[0]).group())
+            new_major = int(re.match(r'\d+', new_parts[0]).group())
+            if new_major > cur_major:
+                bump_type = 'major'
+            elif len(cur_parts) > 1 and len(new_parts) > 1:
+                cur_minor = int(re.match(r'\d+', cur_parts[1]).group())
+                new_minor = int(re.match(r'\d+', new_parts[1]).group())
+                if new_minor > cur_minor:
+                    bump_type = 'minor'
+                else:
+                    bump_type = 'patch'
+            else:
+                bump_type = 'patch'
+        except (ValueError, AttributeError, IndexError):
+            bump_type = 'unknown'
+
+    # Extract dep name from slug (strip trailing version segment)
+    dep_name = re.sub(r'-[\d][\d.]*$', '', dep_slug)
+
+    # CI status
+    checks = pr.get('statusCheckRollup', []) or []
+    ci_status = 'unknown'
+    if checks:
+        states = [c.get('conclusion') or c.get('status', '') for c in checks]
+        if any(s.upper() == 'FAILURE' for s in states):
+            ci_status = 'failing'
+        elif all(s.upper() == 'SUCCESS' for s in states):
+            ci_status = 'passing'
+        else:
+            ci_status = 'pending'
+
+    # Days open
+    try:
+        created_dt = datetime.fromisoformat(created.replace('Z', '+00:00'))
+        days_open = (datetime.now(timezone.utc) - created_dt).days
+    except (ValueError, TypeError):
+        days_open = 0
+
+    total_lines = additions + deletions
+
+    print(f'PR: #{number}')
+    print(f'Title: {title}')
+    print(f'Branch: {branch}')
+    print(f'Ecosystem: {ecosystem}')
+    print(f'Dependency: {dep_name}')
+    print(f'Current version: {current_version}')
+    print(f'New version: {new_version}')
+    print(f'Bump type: {bump_type}')
+    print(f'CI status: {ci_status}')
+    print(f'Lines changed: {total_lines} (+{additions} -{deletions})')
+    print(f'Days open: {days_open}')
+    print('---')
+"
+
+# For each PR, detect dependency location from changed files
+echo ""
+echo "=== DEPENDENCY LOCATIONS ==="
+echo "$PR_JSON" | python3 -c "
+import sys, json
+prs = json.load(sys.stdin)
+for pr in prs:
+    print(f'#{pr[\"number\"]}')
+" | while read -r PR_NUM; do
+  NUM="${PR_NUM#\#}"
+  CHANGED_FILES=$(gh pr diff "$NUM" "${REPO_ARGS[@]}" --name-only 2>/dev/null || echo "")
+
+  LOCATION="unknown"
+  if echo "$CHANGED_FILES" | grep -qiE '(package\.json|Gemfile|requirements.*\.txt|pyproject\.toml|Cargo\.toml|go\.mod|pom\.xml|build\.gradle|\.csproj)'; then
+    # Check if it's a dev dependency by looking at the diff content
+    # For package.json, check devDependencies vs dependencies
+    if echo "$CHANGED_FILES" | grep -q "package.json"; then
+      DIFF_CONTENT=$(gh pr diff "$NUM" "${REPO_ARGS[@]}" 2>/dev/null || echo "")
+      if echo "$DIFF_CONTENT" | grep -q '"devDependencies"'; then
+        LOCATION="dev"
+      else
+        LOCATION="prod"
+      fi
+    else
+      LOCATION="prod"
+    fi
+  fi
+
+  echo "PR $PR_NUM: $LOCATION"
+  echo "Changed files: $CHANGED_FILES"
+  echo "---"
+done


### PR DESCRIPTION
## Summary

- Adds a new `dependabot-analyzer` plugin that automates Dependabot PR triage
- Fans out parallel sub-agents (one per PR) to assess upgrade risk, auto-merges safe patches, diagnoses CI failures, and creates issues for PRs needing human review
- Supports both GitHub Issues and Linear for issue tracking, with per-project config via `.claude/dependabot-analyzer.json`

## Plugin Structure

```
plugins/dependabot-analyzer/
├── .claude-plugin/plugin.json
├── README.md
└── skills/dependabot-analyzer/
    ├── SKILL.md                         # 5-phase workflow
    ├── scripts/discover-prs.sh          # PR discovery via gh CLI
    ├── scripts/check-dep-health.sh      # Package registry health checks
    ├── references/risk-model.md         # 7-factor scoring rubric (0-100)
    ├── references/ci-diagnosis-guide.md # Failure classification + fix protocol
    ├── assets/report-template.md        # Consolidated analysis report
    ├── assets/github-issue-template.md  # Issue body template
    └── assets/config-schema.json        # JSON Schema for user config
```

## Key Design Decisions

- **One agent per PR** (not per risk factor) — cross-cutting analysis requires full PR context
- **Read-only Phase 2, isolated Phase 3** — analysis agents never modify files; CI fix agents use worktree isolation
- **Sequential CI fixes** — prevents branch conflicts between related dependency updates
- **Issue deduplication** — checks for existing open issues before creating new ones (safe for scheduled runs)
- **No built-in scheduling** — relies on Claude Code's native `/schedule` command

## Test plan

- [x] `plugin.json` validates as valid JSON
- [x] `marketplace.json` validates as valid JSON with new entry
- [x] `config-schema.json` validates as valid JSON Schema
- [x] SKILL.md frontmatter passes `quick_validate.py`
- [ ] End-to-end: install plugin, run on a repo with open Dependabot PRs
- [ ] Config edge cases: no config file (defaults), Linear config, `exclude_packages`