### PR TITLE
feat(agent-ready): add session-startup, DoD, and JSON-ledger guidance

### DIFF
--- a/.agents/skills/skill-creator/scripts/quick_validate.py
+++ b/.agents/skills/skill-creator/scripts/quick_validate.py
@@ -1,13 +1,94 @@
 #!/usr/bin/env python3
-"""
-Quick validation script for skills - minimal version
-"""
+"""Quick validation script for skills."""
 
-import sys
-import os
 import re
-import yaml
+import sys
 from pathlib import Path
+
+try:
+    import yaml  # type: ignore
+except ImportError:
+    yaml = None
+
+
+def _parse_scalar(raw_value):
+    """Parse the simple scalar forms used in SKILL.md frontmatter."""
+    value = raw_value.strip()
+
+    if not value:
+        return ""
+
+    if (value.startswith('"') and value.endswith('"')) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        return value[1:-1]
+
+    lowered = value.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+
+    return value
+
+
+def parse_frontmatter(frontmatter_text):
+    """Parse YAML frontmatter with a stdlib fallback for simple repo formats."""
+    if yaml is not None:
+        try:
+            parsed = yaml.safe_load(frontmatter_text)
+        except yaml.YAMLError as exc:
+            raise ValueError(f"Invalid YAML in frontmatter: {exc}") from exc
+        if parsed is None:
+            return {}
+        if not isinstance(parsed, dict):
+            raise ValueError("Frontmatter must be a YAML dictionary")
+        return parsed
+
+    parsed = {}
+    current_key = None
+
+    for line_no, raw_line in enumerate(frontmatter_text.splitlines(), start=1):
+        if not raw_line.strip():
+            continue
+
+        if raw_line.startswith((" ", "\t")):
+            if current_key is None:
+                raise ValueError(
+                    f"Unsupported indentation on line {line_no} without a parent key"
+                )
+
+            stripped = raw_line.strip()
+            if not stripped.startswith("- "):
+                raise ValueError(
+                    "PyYAML is not installed and this frontmatter uses nested YAML "
+                    f"that the fallback parser cannot read (line {line_no})"
+                )
+            if not isinstance(parsed[current_key], list):
+                raise ValueError(
+                    f"Mixed scalar/list values for '{current_key}' on line {line_no}"
+                )
+            parsed[current_key].append(_parse_scalar(stripped[2:]))
+            continue
+
+        if ":" not in raw_line:
+            raise ValueError(f"Invalid frontmatter line {line_no}: {raw_line}")
+
+        key, raw_value = raw_line.split(":", 1)
+        key = key.strip()
+        value = raw_value.strip()
+        current_key = key
+
+        if not key:
+            raise ValueError(f"Missing key on line {line_no}")
+
+        if not value:
+            parsed[key] = []
+            continue
+
+        parsed[key] = _parse_scalar(value)
+
+    return parsed
 
 def validate_skill(skill_path):
     """Basic validation of a skill"""
@@ -30,16 +111,21 @@ def validate_skill(skill_path):
 
     frontmatter_text = match.group(1)
 
-    # Parse YAML frontmatter
     try:
-        frontmatter = yaml.safe_load(frontmatter_text)
-        if not isinstance(frontmatter, dict):
-            return False, "Frontmatter must be a YAML dictionary"
-    except yaml.YAMLError as e:
-        return False, f"Invalid YAML in frontmatter: {e}"
+        frontmatter = parse_frontmatter(frontmatter_text)
+    except ValueError as exc:
+        return False, str(exc)
 
     # Define allowed properties
-    ALLOWED_PROPERTIES = {'name', 'description', 'license', 'allowed-tools', 'metadata', 'compatibility'}
+    ALLOWED_PROPERTIES = {
+        'name',
+        'description',
+        'license',
+        'allowed-tools',
+        'metadata',
+        'compatibility',
+        'disable-model-invocation',
+    }
 
     # Check for unexpected properties (excluding nested keys under metadata)
     unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
@@ -90,6 +176,13 @@ def validate_skill(skill_path):
             return False, f"Compatibility must be a string, got {type(compatibility).__name__}"
         if len(compatibility) > 500:
             return False, f"Compatibility is too long ({len(compatibility)} characters). Maximum is 500 characters."
+
+    disable_model_invocation = frontmatter.get('disable-model-invocation')
+    if disable_model_invocation is not None and not isinstance(disable_model_invocation, bool):
+        return False, (
+            "disable-model-invocation must be a boolean, "
+            f"got {type(disable_model_invocation).__name__}"
+        )
 
     return True, "Skill is valid!"
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -57,7 +57,7 @@
       "name": "agent-ready",
       "source": "./plugins/agent-ready",
       "description": "Make a codebase agent-ready by scaffolding AGENTS.md, ARCHITECTURE.md, and docs/ structure following progressive disclosure patterns. Creates CLAUDE.md as a symlink for Claude Code compatibility.",
-      "version": "1.2.0"
+      "version": "1.3.0"
     },
     {
       "name": "doc-audit",

--- a/plugins/agent-ready/.claude-plugin/plugin.json
+++ b/plugins/agent-ready/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-ready",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Make a codebase agent-ready by scaffolding AGENTS.md, ARCHITECTURE.md, and docs/ structure following progressive disclosure patterns. Creates CLAUDE.md as a symlink for Claude Code compatibility.",
   "author": {
     "name": "Damian Galarza",

--- a/plugins/agent-ready/skills/agent-ready/SKILL.md
+++ b/plugins/agent-ready/skills/agent-ready/SKILL.md
@@ -308,11 +308,12 @@ find . -path "*/decisions/*.md" -o -path "*/adr/*.md" -o -path "*/adrs/*.md" 2>/
 
 **New AGENTS.md:**
 Using the template, generate an AGENTS.md that:
-- Stays under ~100 lines
+- Stays under ~120 lines
 - Leads with project identity and build/test/lint one-liners
 - Includes a **Session Startup** section with the bearing-getting ritual (pwd, git log, smoke test) -- fill in the smoke-test command from detected scripts, or leave a `[TODO: add smoke-test command]` placeholder if nothing is detected
 - Uses directives (must/never/always/avoid/prefer) for conventions
 - Includes a **Definition of Done** section codifying end-to-end verification before marking work complete -- fill in lint/test commands from detected tooling
+- If the repo already uses machine-updated ledgers such as `tasks.json`, status queues, or work trackers, include a directive that names exactly which fields agents may edit
 - Markdown links to existing docs or docs that should be created
 - Includes ADR section if docs/decisions/ or other ADR directories exist
 - Lists max 5 known gotchas
@@ -449,7 +450,18 @@ if [ -f "$DOC" ]; then
 
   # Definition of Done section -- end-to-end verification protocol
   if grep -qiE '^##+ .*(definition of done|verification|done criteria)' "$DOC"; then
-    if grep -qiE 'end-to-end|end to end|browser|exercise' "$DOC"; then
+    DOD_SECTION=$(awk '
+      BEGIN { capture=0 }
+      /^##+[[:space:]]/ {
+        if (capture) exit
+      }
+      /^##+[[:space:]].*(Definition of Done|Verification|Done Criteria)/ {
+        capture=1
+      }
+      capture { print }
+    ' "$DOC")
+
+    if printf "%s\n" "$DOD_SECTION" | grep -qiE 'end-to-end|end to end|browser|exercise'; then
       echo "✓ Definition of Done section present (mentions end-to-end verification)"
     else
       echo "⚠ Definition of Done section present but does not mention end-to-end verification"

--- a/plugins/agent-ready/skills/agent-ready/SKILL.md
+++ b/plugins/agent-ready/skills/agent-ready/SKILL.md
@@ -310,7 +310,9 @@ find . -path "*/decisions/*.md" -o -path "*/adr/*.md" -o -path "*/adrs/*.md" 2>/
 Using the template, generate an AGENTS.md that:
 - Stays under ~100 lines
 - Leads with project identity and build/test/lint one-liners
+- Includes a **Session Startup** section with the bearing-getting ritual (pwd, git log, smoke test) -- fill in the smoke-test command from detected scripts, or leave a `[TODO: add smoke-test command]` placeholder if nothing is detected
 - Uses directives (must/never/always/avoid/prefer) for conventions
+- Includes a **Definition of Done** section codifying end-to-end verification before marking work complete -- fill in lint/test commands from detected tooling
 - Markdown links to existing docs or docs that should be created
 - Includes ADR section if docs/decisions/ or other ADR directories exist
 - Lists max 5 known gotchas
@@ -437,6 +439,24 @@ if [ -f "$DOC" ]; then
     PCT=$(( CODE * 100 / TOTAL ))
     echo "Code example percentage: ${PCT}%"
   fi
+
+  # Session Startup section -- bearing-getting ritual for fresh contexts
+  if grep -qiE '^##+ .*(session startup|getting (started|up to speed)|orient)' "$DOC"; then
+    echo "✓ Session Startup section present"
+  else
+    echo "⚠ MISSING: Session Startup section -- agents have no prescribed orientation sequence on fresh contexts"
+  fi
+
+  # Definition of Done section -- end-to-end verification protocol
+  if grep -qiE '^##+ .*(definition of done|verification|done criteria)' "$DOC"; then
+    if grep -qiE 'end-to-end|end to end|browser|exercise' "$DOC"; then
+      echo "✓ Definition of Done section present (mentions end-to-end verification)"
+    else
+      echo "⚠ Definition of Done section present but does not mention end-to-end verification"
+    fi
+  else
+    echo "⚠ MISSING: Definition of Done section -- no codified end-to-end verification protocol"
+  fi
 fi
 
 # Check symlink status
@@ -507,6 +527,8 @@ Present an actionable report:
 - Code example %: [N]% [OK if <20% / WARNING if >20%]
 - Directive density: [N] directives in [M] lines
 - CLAUDE.md symlink status: [Correct/Needs fix]
+- Session Startup section: [Present/Missing]
+- Definition of Done section: [Present/Missing/Present-without-E2E]
 - Topic overlaps: [list]
 - Broken references: [list]
 - Cross-document conflicts: [list]
@@ -528,3 +550,5 @@ After presenting the report, offer to auto-fix issues:
 - Missing ARCHITECTURE.md entries: offer to run architecture mode to regenerate
 - Missing nested AGENTS.md: offer to create starter files for uncovered domains
 - CLAUDE.md not a symlink: offer to convert it to a symlink to AGENTS.md
+- Missing Session Startup section: offer to insert the bearing-getting ritual (pwd, git log, smoke test) using detected commands
+- Missing Definition of Done section: offer to insert a DoD checklist using detected lint/test commands

--- a/plugins/agent-ready/skills/agent-ready/assets/claude-md-template.md
+++ b/plugins/agent-ready/skills/agent-ready/assets/claude-md-template.md
@@ -19,6 +19,14 @@ Note: This file will be created as AGENTS.md, and CLAUDE.md will be a symlink to
 [run command]                # Start locally
 ```
 
+## Session Startup
+Before making changes, run through these steps to orient on a fresh context:
+1. `pwd` -- confirm working directory
+2. `git log --oneline -10` -- see recent work
+3. Read [PROGRESS.md](./PROGRESS.md) if it exists, otherwise skip
+4. Run `[smoke-test command]` -- verify the app is in a working state
+5. If anything is broken, fix that before starting new work
+
 ## Test
 ```bash
 [test command]               # Run full test suite
@@ -40,6 +48,18 @@ See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full codemap.
 - [Directive 3 -- e.g., "Prefer composition over inheritance"]
 - [Directive 4 -- e.g., "Always validate inputs at service boundaries using [framework/library]"]
 - [Directive 5 -- e.g., "Use [naming convention] for [file type]"]
+
+## Definition of Done
+A change is not complete until:
+- [Type-check / lint command] passes
+- [Test command] passes, including any new tests for the change
+- The feature has been exercised end-to-end, not just unit-tested
+  - Backend changes: hit the actual endpoint, inspect the response
+  - UI changes: load the page in a browser, click through the flow
+- No new warnings in the dev server logs
+- Commit message describes *why*, not just *what*
+
+Do not mark work complete based on "the code looks right" or "the unit tests pass." Verify it actually runs end-to-end.
 
 ## Common Workflows
 - Setup: [docs/guides/setup.md](docs/guides/setup.md)
@@ -75,6 +95,8 @@ Use the [ADR template](docs/decisions/) to document context, the decision, conse
 **Linked docs:** Use markdown links (`[path](path)`) to point to docs that exist or will be created. Each link is a promise that the file contains useful detail the agent can read on demand. Do NOT use `@file` syntax -- that eagerly loads files into context on every conversation, defeating progressive disclosure.
 
 **AGENTS.md vs CLAUDE.md:** AGENTS.md is the canonical file that works with any AI coding agent. CLAUDE.md should be a symlink to AGENTS.md for backward compatibility with Claude Code.
+
+**Structured ledgers -- prefer JSON over Markdown:** For files that track state agents update incrementally (task lists, feature status, work queues), use JSON with a strict schema rather than Markdown. Agents are far less likely to inappropriately edit, reformat, or "improve" a JSON file. Pair it with an explicit directive in AGENTS.md (e.g., "In `tasks.json`, only flip the `status` field -- never edit `description` or `acceptance_criteria`").
 
 **What NOT to include:**
 - Code examples longer than 5 lines (put in a guide)

--- a/plugins/agent-ready/skills/agent-ready/assets/claude-md-template.md
+++ b/plugins/agent-ready/skills/agent-ready/assets/claude-md-template.md
@@ -1,6 +1,6 @@
 # AGENTS.md Template
 
-Use this template when generating a new AGENTS.md. Fill in sections based on actual codebase analysis. Remove sections that do not apply. Target ~100 lines.
+Use this template when generating a new AGENTS.md. Fill in sections based on actual codebase analysis. Remove sections that do not apply. Target ~120 lines.
 
 Note: This file will be created as AGENTS.md, and CLAUDE.md will be a symlink to it for Claude Code compatibility.
 
@@ -23,7 +23,7 @@ Note: This file will be created as AGENTS.md, and CLAUDE.md will be a symlink to
 Before making changes, run through these steps to orient on a fresh context:
 1. `pwd` -- confirm working directory
 2. `git log --oneline -10` -- see recent work
-3. Read [PROGRESS.md](./PROGRESS.md) if it exists, otherwise skip
+3. Read `PROGRESS.md` if it exists, otherwise skip
 4. Run `[smoke-test command]` -- verify the app is in a working state
 5. If anything is broken, fix that before starting new work
 
@@ -88,7 +88,7 @@ Use the [ADR template](docs/decisions/) to document context, the decision, conse
 
 ## Template Notes
 
-**Line budget:** Aim for ~100 lines. If a section exceeds 10 lines, extract the detail to a doc and link to it.
+**Line budget:** Aim for ~120 lines. If a section exceeds 10 lines, extract the detail to a doc and link to it.
 
 **Directive style:** Use must/never/always/avoid/prefer. State the rule, not the rationale. If rationale is needed, put it in a linked doc.
 


### PR DESCRIPTION
## Summary

Adds three patterns to the AGENTS.md template drawn from Anthropic's harness design articles ([Effective harnesses for long-running agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents), [Harness design for long-running application development](https://www.anthropic.com/engineering/harness-design-long-running-apps)), addressing failure modes the existing scaffold did not cover:

- **Session Startup** — bearing-getting ritual (`pwd`, `git log`, smoke test) agents run on every fresh context. Prevents the "look around, declare done" failure mode where an agent piles new work on top of an existing broken state.
- **Definition of Done** — codifies end-to-end verification before marking work complete. Targets the most common over-confidence failure: agents shipping changes because "unit tests pass" without exercising the feature end-to-end.
- **JSON over Markdown for ledgers** — short note in Template Notes capturing Anthropic's finding that agents are far less likely to inappropriately edit JSON files than Markdown ones. Useful guidance when a project adds a task ledger or feature-status file.

`agents-md` mode populates Session Startup and DoD during generation using detected build/test commands. `audit` mode now checks for both sections, flags DoD sections that omit end-to-end verification, and offers matching auto-fixes.

Bumps `agent-ready` to **1.3.0** in `plugin.json` and `marketplace.json`.

## Test plan

- [ ] Run `audit` mode against a project missing Session Startup — confirm it flags as missing and offers fix
- [ ] Run `audit` mode against a project with DoD but no end-to-end mention — confirm "present but does not mention end-to-end verification" warning fires
- [ ] Run `agents-md` mode on a fresh project — confirm generated AGENTS.md contains both new sections with detected commands filled in
- [ ] CI: skill validator + JSON validation pass