### PR TITLE
Add origin/main sync to agent-ready startup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -57,7 +57,7 @@
       "name": "agent-ready",
       "source": "./plugins/agent-ready",
       "description": "Make a codebase agent-ready by scaffolding AGENTS.md, ARCHITECTURE.md, and docs/ structure following progressive disclosure patterns. Creates CLAUDE.md as a symlink for Claude Code compatibility.",
-      "version": "1.3.0"
+      "version": "1.3.1"
     },
     {
       "name": "doc-audit",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this repository will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- **agent-ready v1.3.1** — Session Startup template now tells agents to fetch remote refs and sync with the upstream default branch using the repo's merge or rebase strategy before starting work.
+
 ## [2026.05.22] — 2026-05-22
 
 ### Added

--- a/plugins/agent-ready/.claude-plugin/plugin.json
+++ b/plugins/agent-ready/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-ready",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Make a codebase agent-ready by scaffolding AGENTS.md, ARCHITECTURE.md, and docs/ structure following progressive disclosure patterns. Creates CLAUDE.md as a symlink for Claude Code compatibility.",
   "author": {
     "name": "Damian Galarza",

--- a/plugins/agent-ready/skills/agent-ready/SKILL.md
+++ b/plugins/agent-ready/skills/agent-ready/SKILL.md
@@ -310,7 +310,7 @@ find . -path "*/decisions/*.md" -o -path "*/adr/*.md" -o -path "*/adrs/*.md" 2>/
 Using the template, generate an AGENTS.md that:
 - Stays under ~120 lines
 - Leads with project identity and build/test/lint one-liners
-- Includes a **Session Startup** section with the bearing-getting ritual (pwd, git log, smoke test) -- fill in the smoke-test command from detected scripts, or leave a `[TODO: add smoke-test command]` placeholder if nothing is detected
+- Includes a **Session Startup** section with the bearing-getting ritual (pwd, git log, fetch origin, sync with the upstream default branch using the repo's merge/rebase strategy, smoke test) -- fill in the smoke-test command from detected scripts, or leave a `[TODO: add smoke-test command]` placeholder if nothing is detected
 - Uses directives (must/never/always/avoid/prefer) for conventions
 - Includes a **Definition of Done** section codifying end-to-end verification before marking work complete -- fill in lint/test commands from detected tooling
 - If the repo already uses machine-updated ledgers such as `tasks.json`, status queues, or work trackers, include a directive that names exactly which fields agents may edit
@@ -562,5 +562,5 @@ After presenting the report, offer to auto-fix issues:
 - Missing ARCHITECTURE.md entries: offer to run architecture mode to regenerate
 - Missing nested AGENTS.md: offer to create starter files for uncovered domains
 - CLAUDE.md not a symlink: offer to convert it to a symlink to AGENTS.md
-- Missing Session Startup section: offer to insert the bearing-getting ritual (pwd, git log, smoke test) using detected commands
+- Missing Session Startup section: offer to insert the bearing-getting ritual (pwd, git log, fetch origin, sync with the upstream default branch using the repo's merge/rebase strategy, smoke test) using detected commands
 - Missing Definition of Done section: offer to insert a DoD checklist using detected lint/test commands

--- a/plugins/agent-ready/skills/agent-ready/assets/agent-ready-template.md
+++ b/plugins/agent-ready/skills/agent-ready/assets/agent-ready-template.md
@@ -23,9 +23,11 @@ Note: This file will be created as AGENTS.md, and CLAUDE.md will be a symlink to
 Before making changes, run through these steps to orient on a fresh context:
 1. `pwd` -- confirm working directory
 2. `git log --oneline -10` -- see recent work
-3. Read `PROGRESS.md` if it exists, otherwise skip
-4. Run `[smoke-test command]` -- verify the app is in a working state
-5. If anything is broken, fix that before starting new work
+3. `git fetch origin` -- refresh remote refs before comparing or integrating work
+4. Bring the branch up to date with the upstream default branch (`origin/HEAD`) using the repo's merge or rebase strategy
+5. Read `PROGRESS.md` if it exists, otherwise skip
+6. Run `[smoke-test command]` -- verify the app is in a working state
+7. If anything is broken, fix that before starting new work
 
 ## Test
 ```bash


### PR DESCRIPTION
## Summary
- Add an origin/main fetch + rebase step to the agent-ready AGENTS.md template Session Startup checklist
- Update agent-ready generation/audit guidance to include the same startup behavior
- Bump agent-ready to 1.3.1 and document the change in the changelog

## Validation
- python3 .agents/skills/skill-creator/scripts/quick_validate.py plugins/agent-ready/skills/agent-ready
- python3 -m json.tool plugins/agent-ready/.claude-plugin/plugin.json >/dev/null
- python3 -m json.tool .claude-plugin/marketplace.json >/dev/null