### PR TITLE
docs: fix meeting transcript skill install name

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,7 +33,7 @@ npx skills add dgalarza/claude-code-workflows --skill "tdd-workflow"
 | `tdd-workflow` | Red-green-refactor TDD workflow |
 | `conventional-commits` | Structured commit messages |
 | `parallel-code-review` | Multi-agent code reviews |
-| `process-meeting-transcript` | Process transcripts into notes |
+| `meeting-transcript` | Process transcripts into notes |
 | `gridfinity-planner` | 3D printing baseplate planning |
 
 ```bash

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,7 +33,7 @@ npx skills add dgalarza/claude-code-workflows --skill "tdd-workflow"
 | `tdd-workflow` | Red-green-refactor TDD workflow |
 | `conventional-commits` | Structured commit messages |
 | `parallel-code-review` | Multi-agent code reviews |
-| `meeting-transcript` | Process transcripts into notes |
+| `process-meeting-transcript` | Process transcripts into notes |
 | `gridfinity-planner` | 3D printing baseplate planning |
 
 ```bash

--- a/plugins/meeting-transcript/README.md
+++ b/plugins/meeting-transcript/README.md
@@ -5,7 +5,7 @@ Process raw meeting transcripts into structured notes with action items, summari
 ## Install
 
 ```bash
-npx skills add dgalarza/claude-code-workflows --skill "meeting-transcript"
+npx skills add dgalarza/claude-code-workflows --skill "process-meeting-transcript"
 
 # Or via Claude marketplace
 /plugin install meeting-transcript@dgalarza-workflows


### PR DESCRIPTION
## Summary
- update the meeting transcript plugin README to use the actual process-meeting-transcript skill id for npx install
- keep the Claude marketplace/plugin name as meeting-transcript

## Verification
- rg check confirmed the plugin id and skill id are documented in the correct places
- git diff --check